### PR TITLE
docs: AI agent guide + general/playstore/deploy skills

### DIFF
--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -5,7 +5,12 @@
 ## 포함 내용
 
 - **MCP 서버**: `mimi-seed` (`@yoonion/mimi-seed-mcp`)
-- **스킬**: `appstore-publish` — App Store Connect 릴리스 노트와 스크린샷 업로드
+- **스킬**:
+  - `mimi-seed` — 범용 진입 (상태 점검 → 준비도 → 릴리스 노트 → 스토어 적용)
+  - `playstore-publish` — Google Play 등록정보·이미지·릴리스 노트·트랙 출시/승격
+  - `appstore-publish` — App Store Connect What's New + 스크린샷 업로드
+  - `deploy` — CI 빌드 → 블로커 점검 → 릴리스 노트 → 스토어 적용 풀 파이프라인
+- **에이전트 가이드**: `docs/agent-guide.md` — deferred-tool 로딩(`ToolSearch select:`) 패턴, 호출 순서, 비가역 작업 안전수칙
 
 ## 사전 조건
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,23 @@ Plus MCP resources: `mimi-seed://auth/status` (token state) · `mimi-seed://agen
 
 ---
 
+## Skills & Agent Guide
+
+Bundled skills (auto-loaded by the Claude Code / Codex plugin from [`skills/`](skills/)):
+
+| Skill | Use it for |
+|-------|-----------|
+| `mimi-seed` | General entry — status → readiness → release notes → store apply |
+| `playstore-publish` | Play Store listing, images, release notes, track promote |
+| `appstore-publish` | App Store Connect What's New + screenshots |
+| `deploy` | End-to-end: CI build → blocker check → notes → apply |
+
+Building an agent on top of Mimi Seed? Read **[`docs/agent-guide.md`](docs/agent-guide.md)** —
+how tools load (the deferred-tool / `ToolSearch select:` pattern), the right call order,
+auth model, and which actions are irreversible.
+
+---
+
 ## Local MCP Tool List (110+)
 
 > These run via **Option B (Local MCP)** — Google OAuth on your machine. The Remote MCP (Option A) exposes a smaller ~16-tool read/diagnostic subset.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -1,0 +1,195 @@
+# Agent Guide — Driving Mimi Seed from an AI
+
+> How an AI coding agent (Claude Code, Codex, Cursor, …) should call the Mimi Seed
+> MCP tools correctly. If you are an agent and a user asks you to do app-store /
+> Firebase / AdMob / CI work through `@yoonion/mimi-seed-mcp`, read this first.
+
+The human-facing install + feature docs live in [`README.md`](../README.md). This file
+is the **operational contract for agents**: how tools load, what order to call them in,
+and which actions are irreversible.
+
+---
+
+## 0. The one thing that trips every agent: deferred tools
+
+Mimi Seed exposes **110+ MCP tools**. Harnesses that lazy-load large tool catalogs —
+**Claude Code most notably** — register these tools as **deferred**: the tool *names*
+are visible (in a system reminder), but the **input schemas are not loaded**. If you
+call a deferred tool directly, it fails with `InputValidationError` ("schema not
+loaded"), and it is easy to wrongly conclude "this tool doesn't exist."
+
+**Always load the schema before the first call.** In Claude Code:
+
+```
+ToolSearch(query="select:<tool_name>[,<tool_name>...]")
+```
+
+- Batch every tool you expect to use in one `select:` call — schemas stay loaded for
+  the rest of the session.
+- If `select:` returns no match, fall back to a keyword search
+  (`ToolSearch(query="playstore release promote")`) — exact names sometimes differ.
+- Only if a tool is absent from the deferred list **and** unsearchable is it truly
+  unregistered. Then check the MCP server is connected (see §2), do **not** silently
+  pivot to raw `curl` / `fastlane`.
+
+Other harnesses (Codex with the bundled plugin, Claude Desktop) typically expose the
+tools directly — but the *call order* and *safety rules* below still apply.
+
+### Ready-made `select:` batches
+
+| Goal | `ToolSearch` query |
+|------|--------------------|
+| First contact / "what's connected?" | `select:mimi_seed_status,mimi_seed_auth_status,mimi_seed_auth_start` |
+| Play Store release | `select:playstore_get_app,playstore_list_tracks,playstore_update_latest_release_notes,playstore_promote_release,playstore_submit_release,playstore_check_submission_risks,playstore_plan_release` |
+| Play Store listing + images | `select:playstore_get_listing,playstore_update_listing,playstore_upload_image,playstore_list_images,playstore_replace_images,playstore_delete_all_images` |
+| App Store / TestFlight | `select:appstore_list_apps,appstore_list_versions,appstore_create_version,appstore_get_metadata,appstore_update_whats_new,appstore_list_builds,appstore_attach_latest_build,appstore_submit_for_review,appstore_check_submission_risks,appstore_plan_release` |
+| App Store screenshots | `select:appstore_list_app_info_localizations,appstore_get_metadata,appstore_list_screenshots,appstore_upload_screenshot,appstore_delete_screenshot_set,screenshot_validate` |
+| Release notes from commits | `select:generate_release_notes_from_commits,playstore_update_release_notes,appstore_update_whats_new` |
+| Firebase setup | `select:firebase_list_projects,firebase_get_project,firebase_create_android_app,firebase_create_ios_app,firebase_get_android_config,firebase_enable_common_services` |
+| AdMob | `select:admob_list_accounts,admob_list_apps,admob_create_ad_unit,admob_list_ad_units,admob_get_today_earnings,admob_get_report` |
+| Jenkins credentials | `select:jenkins_status,jenkins_save_config,jenkins_list_credentials,jenkins_create_credential,jenkins_upload_keystore,jenkins_upload_playstore_sa` |
+| CI (GitHub/GitLab) | `select:ci_save_config,ci_list_workflows,ci_trigger_build,ci_get_build_status,ci_list_recent_builds` |
+| Service account end-to-end | `select:iam_create_service_account,iam_create_key,iam_add_iam_policy_binding,playstore_register_service_account,playstore_verify_service_account` |
+
+---
+
+## 1. Always start with `mimi_seed_status`
+
+Before any task, call **`mimi_seed_status`** — the setup doctor. It scans 9 services
+(Google OAuth · Play SA · App Store · Jenkins · CI · Google Ads · Facebook · Instagram ·
+BigQuery) and returns a ✅/❌ report plus the exact next tool to call for anything
+missing. This avoids a late `401`/`403` deep into a workflow.
+
+If auth is missing or expired:
+
+| Service | Fix |
+|---------|-----|
+| Google (Firebase/AdMob/Play) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `npx -y @yoonion/mimi-seed-mcp mimi-seed-auth` |
+| App Store Connect | `npx -y @yoonion/mimi-seed-mcp mimi-seed-appstore-auth` → verify with `appstore_verify_credentials` |
+| Play service account | `npx -y @yoonion/mimi-seed-mcp mimi-seed-playstore-auth`, or register per-package with `playstore_register_service_account` |
+| BigQuery | `npx -y @yoonion/mimi-seed-mcp mimi-seed-bigquery-auth` |
+
+---
+
+## 2. Auth & credential model
+
+Credentials live under `~/.mimi-seed/` (legacy `~/.preseed/` is still read):
+
+| File | Used for |
+|------|----------|
+| `tokens.json` | Google OAuth (Firebase, AdMob, Play Developer API, IAM, BigQuery) |
+| `appstore.json` | App Store Connect API key (JWT) |
+| `play-service-accounts/<packageName>.json` | **per-package** Play service account |
+| `play-service-account.json` | default/legacy Play SA (fallback when no per-package match) |
+| `jenkins.json`, `ci.json` | Jenkins / GitHub-GitLab CI connection |
+
+Notes that matter in practice:
+
+- **Per-package Play SA wins over the default.** Different apps can use SAs from
+  different GCP projects. `playstore_list_service_accounts` shows the mapping.
+- The Play SA's **GCP project must have the Android Publisher API enabled**, or every
+  `playstore_*` call returns `403`.
+- AI features (`generate_release_notes_from_commits`, `generate_review_reply`) need
+  `ANTHROPIC_API_KEY` in the environment.
+
+---
+
+## 3. Tool catalog (by domain)
+
+Full schemas load on demand via `ToolSearch`. Counts are approximate.
+
+| Domain | Representative tools |
+|--------|----------------------|
+| **Google Play** (~26) | `playstore_get_app` · `playstore_get_listing` · `playstore_update_listing` · `playstore_list_tracks` · `playstore_update_latest_release_notes` · `playstore_promote_release` · `playstore_submit_release` · `playstore_upload_image` · `playstore_replace_images` · `playstore_check_submission_risks` · `playstore_get_statistics` · `playstore_reply_review` · `playstore_register_service_account` |
+| **App Store Connect** (~30) | `appstore_list_apps` · `appstore_list_versions` · `appstore_create_version` · `appstore_update_whats_new` · `appstore_update_localization` · `appstore_list_builds` · `appstore_attach_latest_build` · `appstore_upload_screenshot` · `appstore_submit_for_review` · `appstore_cancel_review` · `appstore_list_beta_groups` · `appstore_reply_review` |
+| **Firebase** (~17) | `firebase_create_android_app` · `firebase_create_ios_app` · `firebase_get_android_config` · `firebase_enable_service` · `firebase_enable_common_services` · `firebase_list_*_apps` |
+| **AdMob** (7) | `admob_create_app` · `admob_create_ad_unit` · `admob_list_ad_units` · `admob_get_today_earnings` · `admob_get_report` |
+| **CI/CD** (6) | `ci_trigger_build` · `ci_get_build_status` · `ci_list_workflows` (**GitHub Actions / GitLab only**) |
+| **Jenkins** (credentials) | `jenkins_status` · `jenkins_save_config` · `jenkins_create_credential` · `jenkins_upload_keystore` · `jenkins_upload_playstore_sa` |
+| **Google Cloud IAM** (5) | `iam_create_service_account` · `iam_create_key` · `iam_add_iam_policy_binding` |
+| **BigQuery** (5) | `bigquery_run_query` · `bigquery_list_datasets` · `bigquery_get_table_schema` |
+| **Search Console** (6) | `gsc_inspect_url` · `gsc_search_analytics` · `gsc_submit_sitemap` |
+| **Facebook / Instagram** (10) | `facebook_post_photo` · `instagram_post_carousel` |
+| **Checks** (4) | `playstore_check_submission_risks` · `appstore_check_submission_risks` · `screenshot_validate` · `release_status` |
+| **AI / Auth** (4) | `generate_release_notes_from_commits` · `generate_review_reply` · `mimi_seed_status` · `mimi_seed_auth_status` |
+
+---
+
+## 4. Workflows (call sequences)
+
+### Play Store release / promote
+1. `playstore_list_tracks` — see current track/version state.
+2. `playstore_check_submission_risks` (or `playstore_plan_release`) — surface blockers.
+3. Write missing listing/notes (`playstore_update_listing`, `playstore_update_latest_release_notes`, `playstore_upload_image`).
+4. `playstore_promote_release` / `playstore_submit_release` — **confirm first** (see §5).
+
+### App Store TestFlight → review
+1. `appstore_list_apps` → `appstore_list_versions` (or `appstore_create_version`).
+2. `appstore_list_builds` → `appstore_attach_latest_build` (only `processingState=VALID`).
+3. `appstore_update_whats_new`, screenshots if needed.
+4. `appstore_check_submission_risks` → `appstore_submit_for_review` — **confirm first**.
+
+### Release notes from git
+`generate_release_notes_from_commits` (pass commit array + locales) → review with user →
+`playstore_update_release_notes` / `appstore_update_whats_new`.
+
+> **Mimi Seed does not compile app binaries.** It manages metadata, store releases, and
+> CI/Jenkins *credentials* — not Xcode/Gradle builds. To produce an `.ipa`/`.aab`, use
+> EAS, Xcode, or a CI/Jenkins job. There is **no `jenkins_trigger_build` tool**; trigger
+> a Jenkins job via its REST API and use the `jenkins_*` tools only for credentials.
+
+---
+
+## 5. Safety — irreversible actions need explicit confirmation
+
+Never run these without the user's go-ahead in the same turn:
+
+| Action | Why |
+|--------|-----|
+| `playstore_submit_release` / `playstore_promote_release` with `status=completed` | Starts Google review / full rollout. Near-irreversible. |
+| `appstore_submit_for_review` | Submits to Apple review. |
+| `appstore_delete_screenshot_set`, `playstore_delete_all_images` | Deletes assets. |
+| `playstore_delete_product`, `jenkins_delete_credential`, `firebase_delete_*_app` | Destructive. |
+
+General rules:
+- Run `*_check_submission_risks` / `*_plan_release` **before** submitting, and show
+  blockers to the user as a checklist first.
+- Pass file paths as **absolute paths**; never load image bytes into the conversation.
+- Prefer `status=draft` while iterating; flip to `completed` only on explicit request.
+
+---
+
+## 6. Known gotchas (learned the hard way)
+
+- **Draft-app track constraint (Play).** Until an app has its first non-internal
+  publish, only the **`internal`** track can be `completed`. `alpha`/`beta`/`production`
+  reject anything but `draft` → error: *"Only releases with status draft may be created
+  on draft app."* Closed/open testing also needs the **App Content** declarations
+  (content rating, data safety, target audience) which are **Console-only** — the API
+  cannot set them.
+- **Store-listing text vs images can route differently.** `playstore_upload_image`
+  (icon/screenshots) and `playstore_update_listing` (description text) both need
+  "Manage store presence", but may resolve credentials differently. If images upload
+  but text returns `403`, it is a credential-routing issue, **not** the user's Play
+  Console permissions — verify with a read (`playstore_get_listing`) and, if needed,
+  fall back to entering text in Console.
+- **`ci_*` is GitHub/GitLab only.** It does not trigger Jenkins builds.
+- **Reward/cash-out apps** are a sensitive Play category — flag policy implications to
+  the user, but it does not block test-track distribution.
+
+---
+
+## 7. Slash commands & MCP resources
+
+Available in any MCP client as native slash commands:
+
+- `/mimi-seed:deploy` — blockers → release notes → apply to stores
+- `/mimi-seed:health` — auth status + readiness summary
+- `/mimi-seed:review-inbox` — fetch unanswered reviews → draft replies
+
+MCP resources: `mimi-seed://auth/status` (token state) · `mimi-seed://agent/guide`
+(agent role definition).
+
+---
+
+_Keep this guide in sync with `README.md`'s tool list and the `skills/` directory._

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: deploy
+description: CI 빌드 → 출시 준비도 점검 → 릴리스 노트 생성 → 스토어 적용을 잇는 mimi-seed 풀 배포 파이프라인 스킬. Use when running an end-to-end release (build → check → notes → apply) via the mimi-seed MCP / CLI across Play Store and App Store.
+---
+
+# deploy
+
+mimi-seed로 출시를 한 흐름으로 운전한다: CI 빌드 → 블로커 점검 → 릴리스 노트 생성/적용 → 스토어 출시. CLI 한 줄(`mimi-seed deploy`) 또는 MCP 도구 시퀀스 두 경로를 지원한다.
+
+## 사전 조건
+
+1. MCP에 `mimi-seed` 등록 + 대상 스토어 인증 완료 (`mimi_seed_status`로 확인).
+2. AI 릴리스 노트를 쓰려면 `ANTHROPIC_API_KEY` 환경변수.
+3. CI 연결: GitHub Actions / GitLab은 `ci_save_config`. **Jenkins는 빌드 트리거 도구가 없으므로** 잡을 REST API로 직접 트리거하고, mimi-seed의 `jenkins_*`는 credential 등록에만 쓴다.
+
+## 경로 A — CLI (가장 간단)
+
+```bash
+npx mimi-seed deploy                           # Android, CI 자동 감지
+npx mimi-seed deploy --platform ios            # iOS
+npx mimi-seed deploy --skip-build --version-code 142   # 노트만 적용
+```
+
+CI(Jenkins · GitHub Actions · GitLab) 자동 감지, `--ci`로 강제 지정 가능.
+
+## 경로 B — MCP 도구 시퀀스
+
+1. 도구 로드:
+   ```
+   ToolSearch(query="select:mimi_seed_status,ci_list_workflows,ci_trigger_build,ci_get_build_status,generate_release_notes_from_commits,playstore_check_submission_risks,playstore_update_latest_release_notes,playstore_promote_release,appstore_list_builds,appstore_attach_latest_build,appstore_update_whats_new,appstore_submit_for_review")
+   ```
+2. **빌드**: `ci_trigger_build`(GitHub/GitLab) → `ci_get_build_status`로 완료 대기. (Jenkins면 REST 트리거 후 빌드 로그 폴링.)
+3. **노트**: git 커밋 배열을 `generate_release_notes_from_commits`(3톤 × 다국어)로 생성 → 사용자 리뷰 → 적용.
+4. **점검**: `playstore_check_submission_risks` / `appstore_check_submission_risks` 블로커 보고.
+5. **적용**:
+   - Android: `playstore_update_latest_release_notes` → `playstore_promote_release`/`submit_release`
+   - iOS: `appstore_attach_latest_build` → `appstore_update_whats_new` → `appstore_submit_for_review`
+
+## 안전 규칙
+
+- 빌드 산출물 업로드와 스토어 출시는 외부 노출/비가역 작업 — 출시(`status=completed`, `submit_for_review`) 전 **반드시 사용자 승인**.
+- 점검(`*_check_submission_risks`)을 출시보다 먼저 돌려 블로커를 체크리스트로 보여준다.
+- TestFlight/스토어 업로드는 처리 시간이 있으니 상태를 폴링하고 결과를 요약한다.
+- mimi-seed는 빌드 바이너리를 직접 만들지 않는다 — 컴파일은 CI/Jenkins/EAS 잡이 담당.

--- a/skills/mimi-seed/SKILL.md
+++ b/skills/mimi-seed/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: mimi-seed
+description: mimi-seed MCP(@yoonion/mimi-seed-mcp)로 Google Play·App Store Connect·Firebase·AdMob 출시 운영을 Claude Code/Codex에서 바로 실행하는 범용 진입 스킬. deferred-tool 로딩(ToolSearch select)과 비가역 작업 안전수칙을 포함한다. Use when a user asks to do app-store / Firebase / AdMob / CI ops via the mimi-seed MCP and you need the correct tool-loading order, workflows, and safety rules.
+---
+
+# mimi-seed
+
+mimi-seed MCP 서버의 110+ 도구로 앱 출시 운영(상태 점검 · 출시 준비도 · 릴리스 노트 · 스토어 적용 · Firebase/AdMob 설정)을 대화형으로 수행하는 범용 스킬. 도메인별 세부 작업은 `appstore-publish` · `playstore-publish` · `deploy` 스킬로 분기하고, 깊은 규약은 리포의 [`docs/agent-guide.md`](../../docs/agent-guide.md)를 참조한다.
+
+## 사전 조건
+
+1. MCP 클라이언트(Claude Code / Codex / Claude Desktop)에 `mimi-seed`가 등록되어 있어야 한다.
+2. 작업 대상 서비스 인증이 되어 있어야 한다 (`~/.mimi-seed/` 하위). 미인증 시:
+   ```bash
+   npx -y @yoonion/mimi-seed-mcp mimi-seed-auth            # Google (Firebase/AdMob/Play)
+   npx -y @yoonion/mimi-seed-mcp mimi-seed-appstore-auth   # App Store Connect
+   npx -y @yoonion/mimi-seed-mcp mimi-seed-playstore-auth  # Play service account
+   ```
+
+## 도구 로딩 (가장 중요)
+
+Claude Code 등은 mimi-seed 도구를 **deferred**로 노출한다 — 이름은 보이지만 schema 미로드 상태라 **직접 호출하면 `InputValidationError`** 가 난다. **반드시 호출 전에 schema를 로드**한다:
+
+```
+ToolSearch(query="select:<tool>[,<tool>...]")
+```
+
+- 한 작업에 필요한 도구를 한 번에 batch select (세션 동안 유지됨).
+- `select:`가 비면 키워드 검색으로 폴백. 그래도 없으면 그때만 미등록으로 판단하고, curl/fastlane로 우회하지 말 것.
+- 자주 쓰는 select 배치는 `docs/agent-guide.md` §0 표 참조.
+
+## 실행 흐름
+
+1. **`mimi_seed_status` 먼저 호출** — 9개 서비스 연결을 ✅/❌로 스캔하고 미설정 항목별 다음 도구를 알려준다. 인증 누락이면 위 auth 명령으로 안내.
+2. 작업 의도를 파악해 분기:
+   - Play 스토어 출시/승격/리스팅 → `playstore-publish` 스킬
+   - App Store 메타데이터/스크린샷/TestFlight → `appstore-publish` 스킬
+   - CI 빌드→점검→노트→적용 풀 파이프라인 → `deploy` 스킬
+   - Firebase/AdMob/IAM/BigQuery → 해당 도메인 도구 직접
+3. 스토어 **쓰기 전** `*_check_submission_risks` 또는 `*_plan_release`로 블로커를 먼저 점검하고 사용자에게 체크리스트로 보고.
+4. 적용 후 결과·실패 지점을 요약.
+
+## 안전 규칙
+
+- 비가역 작업(`playstore_submit_release`/`promote_release` `status=completed`, `appstore_submit_for_review`, 스크린샷 셋 삭제, 상품/크리덴셜 삭제)은 **같은 턴에서 명시 승인** 없이는 실행하지 않는다.
+- 반복 작업 중에는 `status=draft`를 쓰고, `completed` 전환은 명시 요청 시에만.
+- 파일은 절대경로로 전달하고, 이미지 바이트를 대화 컨텍스트에 싣지 않는다.
+- mimi-seed는 **앱 바이너리를 빌드하지 않는다** (메타데이터·릴리스·credential 관리 전용). `.ipa`/`.aab`는 EAS·Xcode·CI/Jenkins 잡으로 만든다.

--- a/skills/playstore-publish/SKILL.md
+++ b/skills/playstore-publish/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: playstore-publish
+description: mimi-seed MCP로 Google Play 스토어 등록정보·이미지·릴리스 노트를 업로드하고 트랙 출시/승격을 처리한다. Use when publishing Android Play Store metadata, images, or releasing/promoting a track via the mimi-seed MCP.
+---
+
+# playstore-publish
+
+mimi-seed MCP 서버(`@yoonion/mimi-seed-mcp`)의 Google Play 도구로 스토어 등록정보(제목/설명), 이미지(아이콘/스크린샷), 릴리스 노트를 업로드하고 트랙 출시·승격을 수행한다. 프로젝트 중립 스킬이며, 각 프로젝트의 `CLAUDE.md`/`AGENTS.md`에 있는 패키지명과 Android 스크린샷 매니페스트를 참조한다.
+
+## 사전 조건
+
+1. MCP에 `mimi-seed`가 등록되어 있어야 한다.
+2. Play 서비스 계정 인증(`~/.mimi-seed/play-service-accounts/<packageName>.json` 또는 default)이 있어야 한다. 미설정 시:
+   ```bash
+   npx -y @yoonion/mimi-seed-mcp mimi-seed-playstore-auth
+   ```
+   또는 `playstore_register_service_account`로 패키지별 등록. SA의 GCP 프로젝트에 **Android Publisher API가 활성화**되어 있어야 한다 (아니면 모든 호출 403).
+
+## 도구 로딩
+
+호출 전 schema 로드:
+```
+ToolSearch(query="select:playstore_get_app,playstore_get_listing,playstore_update_listing,playstore_list_tracks,playstore_upload_image,playstore_list_images,playstore_update_latest_release_notes,playstore_promote_release,playstore_submit_release,playstore_check_submission_risks,playstore_plan_release")
+```
+
+## 실행 흐름
+
+1. `playstore_list_tracks` — 현재 트랙별 버전/상태(production/beta/alpha/internal) 확인.
+2. `playstore_check_submission_risks` — 블로커(전체 설명/스크린샷/아이콘 등) 점검 후 사용자에게 체크리스트로 보고.
+3. 누락분 업로드:
+   - 텍스트: `playstore_update_listing` (title ≤30 / short ≤80 / full ≤4000)
+   - 이미지: `playstore_upload_image` (아래 표의 imageType·해상도 준수)
+   - 노트: `playstore_update_latest_release_notes`
+4. 출시/승격은 **사용자 승인 후**:
+   - 같은 트랙 출시: `playstore_submit_release`
+   - 트랙 간 승격: `playstore_promote_release` (fromTrack→toTrack, versionCode)
+
+## 안전 규칙
+
+- `status=completed`(전체 출시/Google 검토 시작)는 비가역에 가깝다 — 명시 승인 없이는 `draft` 유지.
+- **Draft 앱 제약**: 앱이 첫 게시 전이면 `internal` 트랙만 `completed` 가능, alpha/beta/production은 `draft`만 생성됨. 비공개/공개 테스트 출시는 콘텐츠 등급·데이터 보안·타깃 연령(Console 전용) 완료가 선행되어야 한다.
+- 이미지 전체 삭제(`playstore_delete_all_images`)는 되돌릴 수 없으니 수량을 먼저 알린다.
+- 파일은 절대경로. 이미지 바이트를 컨텍스트에 싣지 않는다.
+
+## imageType 참고
+
+| imageType | 규격 |
+| --- | --- |
+| `icon` | 512×512 PNG |
+| `featureGraphic` | 1024×500 |
+| `phoneScreenshots` | 320–3840px (각 변), 최소 2장 |
+| `sevenInchScreenshots` / `tenInchScreenshots` | 태블릿 |
+
+업로드 전 실제 PNG 해상도를 확인한다.


### PR DESCRIPTION
## What

- **docs/agent-guide.md** — the operational contract for AI agents driving the mimi-seed MCP:
  - the **deferred-tool pattern** (`ToolSearch select:` before the first call) — the #1 reason agents fail in Claude Code (`InputValidationError`)
  - `mimi_seed_status`-first flow, auth & credential model (`~/.mimi-seed/`)
  - tool catalog by domain + ready-made `select:` batches per workflow
  - workflow call sequences (Play release, App Store / TestFlight, release notes)
  - irreversible-action safety rules + known gotchas (draft-app track constraint, store-listing vs image 403 routing, `ci_*` is GitHub/GitLab only)
- **3 new project-neutral skills** next to existing `appstore-publish`:
  - `mimi-seed` — general entry (status -> readiness -> notes -> apply)
  - `playstore-publish` — Play listing / images / notes / track promote
  - `deploy` — CI build -> blocker check -> notes -> apply
- Linked from `README.md` (new "Skills & Agent Guide" section) and `.codex-plugin/README.md`

## Why

The deferred-tool / `ToolSearch select:` knowledge currently lives only in private user rules, so AI agents repeatedly hit `InputValidationError` and wrongly conclude tools are missing. Publishing it lets every MCP client (Claude Code / Codex / Cursor) drive mimi-seed correctly out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)