### PR TITLE
fix(playstore): surface raw 403 reason + warn that API edits overwrite Console changes

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -167,12 +167,17 @@ General rules:
   on draft app."* Closed/open testing also needs the **App Content** declarations
   (content rating, data safety, target audience) which are **Console-only** — the API
   cannot set them.
-- **Store-listing text vs images can route differently.** `playstore_upload_image`
-  (icon/screenshots) and `playstore_update_listing` (description text) both need
-  "Manage store presence", but may resolve credentials differently. If images upload
-  but text returns `403`, it is a credential-routing issue, **not** the user's Play
-  Console permissions — verify with a read (`playstore_get_listing`) and, if needed,
-  fall back to entering text in Console.
+- **A `403` on one write but not another is usually NOT a permissions gap.** Every
+  `playstore_*` write resolves the same credential (`requirePlayStoreAuth`), so if
+  `playstore_upload_image` succeeds but `playstore_update_listing` returns `403`, the
+  account's permissions are fine. Read the **raw Google reason** surfaced in the error
+  (app state, policy, or an operation-specific restriction) instead of blindly
+  "granting permission" — the friendly 403 message now includes that reason.
+- **Play edits overwrite un-published Console changes.** Committing *any* Play
+  Developer API edit (image upload, listing update, release) discards listing/release
+  changes you saved-but-didn't-publish in the Play Console UI. Google's own docs warn
+  against editing the same app with both tools at once. Do all listing writes via the
+  API, or finish & publish your Console edits first — never interleave them.
 - **`ci_*` is GitHub/GitLab only.** It does not trigger Jenkins builds.
 - **Reward/cash-out apps** are a sensitive Play category — flag policy implications to
   the user, but it does not block test-track distribution.

--- a/packages/mcp-server/src/__tests__/google-errors.test.ts
+++ b/packages/mcp-server/src/__tests__/google-errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { friendlyGoogleError, extractHttpStatus, authReauthMessage } from '../lib/google-errors.js';
+import { friendlyGoogleError, extractHttpStatus, authReauthMessage, googleErrorDetail } from '../lib/google-errors.js';
 import { friendlyPlayError } from '../playstore/errors.js';
 
 describe('extractHttpStatus', () => {
@@ -20,6 +20,21 @@ describe('authReauthMessage', () => {
   });
   it('null for unrelated text', () => {
     expect(authReauthMessage('some random error')).toBeNull();
+  });
+});
+
+describe('googleErrorDetail', () => {
+  it('extracts response.data.error.message', () => {
+    const e = { response: { data: { error: { message: 'The caller does not have permission' } } } };
+    expect(googleErrorDetail(e)).toContain('does not have permission');
+  });
+  it('extracts errors[].reason', () => {
+    const e = { errors: [{ reason: 'insufficientPermissions', message: 'nope' }] };
+    expect(googleErrorDetail(e)).toContain('insufficientPermissions');
+  });
+  it('undefined when no structured detail', () => {
+    expect(googleErrorDetail(new Error('forbidden'))).toBeUndefined();
+    expect(googleErrorDetail('x')).toBeUndefined();
   });
 });
 
@@ -51,6 +66,12 @@ describe('friendlyPlayError', () => {
   it('403 status -> Play Console permission checklist', () => {
     const m = friendlyPlayError({ code: 403, message: 'forbidden' }).message;
     expect(m).toContain('Users and permissions');
+  });
+  it('403 with Google detail surfaces the raw reason (not just "grant permission")', () => {
+    const e = { code: 403, response: { data: { error: { message: 'Operation not allowed for this app state' } } } };
+    const m = friendlyPlayError(e).message;
+    expect(m).toContain('Operation not allowed for this app state');
+    expect(m).toContain('Users and permissions'); // checklist still present as fallback
   });
   it('404 -> packageName hint includes the package', () => {
     const m = friendlyPlayError({ code: 404, message: 'not found' }, 'com.example.app').message;

--- a/packages/mcp-server/src/lib/google-errors.ts
+++ b/packages/mcp-server/src/lib/google-errors.ts
@@ -24,6 +24,33 @@ export function rawMessage(e: unknown): string {
   }
 }
 
+/**
+ * Google API 에러에서 구조화된 실제 사유를 추출한다. GaxiosError는
+ * `response.data.error.{message,errors[].reason}` 에 진짜 원인을 담는데,
+ * 친절화 레이어가 이를 버리고 일반 메시지("권한 없음")로 덮으면, 권한이 멀쩡한데도
+ * 권한 문제로 오진하게 된다 (예: 같은 SA로 이미지 업로드는 되는데 listings.update만 403).
+ * 추출 실패 시 undefined.
+ */
+export function googleErrorDetail(e: unknown): string | undefined {
+  if (!e || typeof e !== 'object') return undefined;
+  const any = e as {
+    errors?: Array<{ reason?: string; message?: string }>;
+    response?: { data?: { error?: { message?: unknown; errors?: Array<{ reason?: string; message?: string }> } } };
+  };
+  const apiErr = any.response?.data?.error;
+  const parts: string[] = [];
+  if (apiErr?.message) parts.push(String(apiErr.message));
+  const reasons = apiErr?.errors ?? any.errors;
+  if (Array.isArray(reasons)) {
+    for (const r of reasons) {
+      const bit = [r?.reason, r?.message].filter(Boolean).join(': ');
+      if (bit && !parts.some((p) => p.includes(bit))) parts.push(bit);
+    }
+  }
+  const joined = parts.join(' | ').trim();
+  return joined.length ? joined : undefined;
+}
+
 /** invalid_grant / 만료 refresh_token / 부족 scope → 재로그인 안내 메시지. 아니면 null. */
 export function authReauthMessage(text: string): string | null {
   if (/invalid_grant|invalid_rapt|rapt_required|unauthorized_client|ACCESS_TOKEN_SCOPE_INSUFFICIENT|insufficient.*scope/i.test(text)) {

--- a/packages/mcp-server/src/playstore/errors.ts
+++ b/packages/mcp-server/src/playstore/errors.ts
@@ -3,18 +3,24 @@
 // 신규 사용자가 가장 자주 막히는 두 케이스(서비스 계정 권한 403, edit 세션 충돌)에
 // 구체적 복구 단계를 붙인다. 인식 못 한 에러(도메인 에러 포함)는 원본 보존.
 
-import { extractHttpStatus, authReauthMessage, withCause } from '../lib/google-errors.js';
+import { extractHttpStatus, authReauthMessage, withCause, googleErrorDetail } from '../lib/google-errors.js';
 
-// playstore_verify_service_account 의 403 안내와 동일한 체크리스트.
-const PERMISSION_403 = [
-  '❌ Google Play 권한 부족 (403).',
-  '원인: 인증은 됐지만 Play Console에서 이 계정/서비스 계정에 권한이 없어요.',
-  '',
-  '1. Play Console → 사용자 및 권한(Users and permissions)',
-  '2. 이 Google 계정(또는 서비스 계정 이메일)을 초대 / 권한 부여',
-  '3. 앱 권한에 "앱 정보 관리" (재무 데이터 필요 시 "재무 데이터 보기") 부여',
-  '4. 권한 적용까지 ~5분 대기 후 재시도 (너무 빨리 시도하면 계속 403)',
-].join('\n');
+// 403 안내. raw Google 사유를 먼저 보여주고, 권한이 멀쩡한데 특정 작업만 거부되는
+// 케이스(같은 SA로 이미지 업로드는 되는데 listings.update만 403 등)를 위해
+// "다른 쓰기가 되면 권한 문제가 아니다"라는 단서를 붙인다. detail 은 googleErrorDetail() 결과.
+function permission403Message(detail?: string): string {
+  return [
+    '❌ Google Play 403 — 요청이 거부됐어요.',
+    detail ? `Google 사유: ${detail}` : '',
+    '⚠️ 같은 계정/서비스 계정으로 다른 쓰기(예: 이미지 업로드)가 된다면 권한 문제가 아닐 수 있어요 — 위 Google 사유 또는 앱 상태·정책·작업별 제한을 먼저 확인하세요.',
+    '',
+    '정말 권한 문제라면:',
+    '1. Play Console → 사용자 및 권한(Users and permissions)',
+    '2. 이 Google 계정(또는 서비스 계정 이메일)을 초대 / 권한 부여',
+    '3. 앱 권한에 "앱 정보 관리"(Manage store presence) 부여',
+    '4. 권한 적용까지 ~5분 대기 후 재시도',
+  ].filter((l) => l !== '').join('\n');
+}
 
 export function friendlyPlayError(e: unknown, packageName?: string): Error {
   const text = e instanceof Error ? e.message : String(e);
@@ -24,7 +30,7 @@ export function friendlyPlayError(e: unknown, packageName?: string): Error {
   if (reauth) return withCause(new Error(reauth), e);
 
   if (status === 403 || /PERMISSION_DENIED|insufficient permission|forbidden/i.test(text)) {
-    return withCause(new Error(PERMISSION_403), e);
+    return withCause(new Error(permission403Message(googleErrorDetail(e))), e);
   }
   if (status === 404 || /NOT_FOUND|not found/i.test(text)) {
     return withCause(

--- a/packages/mcp-server/src/registers/playstore.ts
+++ b/packages/mcp-server/src/registers/playstore.ts
@@ -68,7 +68,7 @@ export function registerPlaystoreTools(server: McpServer) {
 
   server.tool(
     'playstore_update_listing',
-    'Google Play 스토어 리스팅 수정 (제목, 설명문 변경)',
+    'Google Play 스토어 리스팅 수정 (제목, 설명문 변경). ⚠️ Play API 편집과 Console 동시 편집은 충돌 — Console에서 같은 리스팅을 편집·미게시 중이면 그 변경이 덮어써질 수 있음.',
     {
       packageName: z.string().describe('패키지명'),
       language: z.string().describe('언어 코드 (예: ko-KR, en-US)'),
@@ -161,7 +161,7 @@ export function registerPlaystoreTools(server: McpServer) {
 
   server.tool(
     'playstore_upload_image',
-    'Google Play 리스팅 이미지 단일 업로드 (기존 이미지 유지). featureGraphic 1024x500 / icon 512x512 / phoneScreenshots 320~3840px',
+    'Google Play 리스팅 이미지 단일 업로드 (기존 이미지 유지). featureGraphic 1024x500 / icon 512x512 / phoneScreenshots 320~3840px. ⚠️ 이 작업은 edit을 commit하므로 Play Console의 미게시(저장 전) 리스팅 변경을 덮어쓸 수 있음 — Console에서 같은 앱을 편집 중이면 먼저 저장·게시하거나 텍스트도 update_listing으로 처리하세요.',
     {
       packageName: z.string().describe('패키지명'),
       language: z.string().describe('언어 코드'),
@@ -177,7 +177,7 @@ export function registerPlaystoreTools(server: McpServer) {
 
   server.tool(
     'playstore_delete_all_images',
-    'Google Play 리스팅 특정 imageType의 이미지 전체 삭제 (교체 전 정리)',
+    'Google Play 리스팅 특정 imageType의 이미지 전체 삭제 (교체 전 정리). ⚠️ commit이 Play Console의 미게시 리스팅 변경을 덮어쓸 수 있음.',
     {
       packageName: z.string().describe('패키지명'),
       language: z.string().describe('언어 코드'),
@@ -192,7 +192,7 @@ export function registerPlaystoreTools(server: McpServer) {
 
   server.tool(
     'playstore_replace_images',
-    'Google Play 리스팅 이미지 일괄 교체 (한 edit 세션: deleteall → 순서대로 upload → commit). 스크린샷 5~8장 한 번에 교체 시 효율적. 업로드 순서가 스토어 노출 순서',
+    'Google Play 리스팅 이미지 일괄 교체 (한 edit 세션: deleteall → 순서대로 upload → commit). 스크린샷 5~8장 한 번에 교체 시 효율적. 업로드 순서가 스토어 노출 순서. ⚠️ commit이 Play Console의 미게시 리스팅 변경을 덮어쓸 수 있음.',
     {
       packageName: z.string().describe('패키지명'),
       language: z.string().describe('언어 코드'),


### PR DESCRIPTION
## Symptom

Two real problems surfaced while publishing a Play Store listing through the MCP:

1. **`playstore_update_listing` returned `403`** even though the service account had full store permissions — image uploads with the *same* credential succeeded. The friendly error said "grant permission in Play Console", which was wrong and caused a long debugging detour.
2. **Uploading images wiped the store description** that had been typed in the Play Console UI.

## Root cause

- Every `playstore_*` write resolves the **same** credential via `requirePlayStoreAuth`, so a 403 on one write but not another is *not* a permissions/routing gap. But `friendlyPlayError` discarded the raw Google reason and always rendered the generic "grant permission" checklist, hiding the real cause.
- `playstore_upload_image` (and any committing tool) runs `edits.insert -> ... -> edits.commit`. Committing a Play Developer API edit **discards un-published Play Console changes** — Google's own docs warn against editing the same app with both tools at once. So each image commit wiped the un-published description.

## Changes

- `google-errors`: `googleErrorDetail()` extracts `response.data.error.message` / `errors[].reason`.
- `playstore/errors`: the 403 message now **leads with the raw Google reason** and notes that if other writes succeed the cause is not permissions (checklist kept as fallback).
- `registers/playstore`: `upload_image` / `update_listing` / `replace_images` / `delete_all_images` descriptions warn that committing an edit overwrites un-published Console changes.
- `docs/agent-guide`: corrected the 403 gotcha (same credential for all writes) and added the API-edit-overwrites-Console gotcha.
- Tests: `googleErrorDetail` + a 403-with-detail case. **143 passing**, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)