### PR TITLE
feat(mcp): Firebase/AdMob/GA4 attach (provisioning + CLI)

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.2.11",
+      "version": "0.3.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "description": "Mimi Seed CLI — Claude Code와 Codex에서 앱 출시 운영을 관리합니다.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/cli/src/cloud.ts
+++ b/packages/cli/src/cloud.ts
@@ -1,0 +1,40 @@
+// `mimi-seed firebase|admob|ga4 ...` 서브명령 — Firebase/AdMob/GA4 attach 의 front door.
+// 실제 로직은 @yoonion/mimi-seed-mcp 의 mimi-seed-firebase / -admob / -ga4 sub-CLI 에 있고,
+// 이 래퍼는 npx 로 호출해 stdio 그대로 패스스루한다 (auth.ts:runMcpBin 패턴과 동일).
+// 사용자가 mimi-seed 한 패키지만 알아도 클라우드 리소스 프로비저닝 사이클을 돌릴 수 있게 한다.
+
+import { spawn } from "node:child_process";
+
+const MCP_PKG = "@yoonion/mimi-seed-mcp";
+
+async function runMcpBin(bin: string, extraArgs: string[]): Promise<number> {
+  return new Promise((resolve) => {
+    // npx 로 해당 bin 실행. stdio inherit 로 진행 출력 그대로 보임.
+    // Windows / POSIX 양쪽 호환을 위해 shell:true.
+    const child = spawn("npx", ["-y", `${MCP_PKG}`, bin, ...extraArgs], {
+      stdio: "inherit",
+      shell: true,
+    });
+    child.on("error", (e) => {
+      process.stderr.write(`\n  ❌ npx 실행 실패: ${e.message}\n`);
+      resolve(1);
+    });
+    child.on("exit", (code) => resolve(code ?? 0));
+  });
+}
+
+function exitWith(code: number): void {
+  if (code !== 0) process.exit(code);
+}
+
+export async function cmdFirebase(args: string[]): Promise<void> {
+  exitWith(await runMcpBin("mimi-seed-firebase", args));
+}
+
+export async function cmdAdmob(args: string[]): Promise<void> {
+  exitWith(await runMcpBin("mimi-seed-admob", args));
+}
+
+export async function cmdGa4(args: string[]): Promise<void> {
+  exitWith(await runMcpBin("mimi-seed-ga4", args));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import { cmdCheck } from "./check.js";
 import { cmdNotes } from "./notes.js";
 import { cmdReview } from "./review.js";
 import { cmdAuth } from "./auth.js";
+import { cmdFirebase, cmdAdmob, cmdGa4 } from "./cloud.js";
 import { cmdDeploy } from "./deploy.js";
 import { cmdRestart } from "./mcp-restart.js";
 import { printMcpSetup, writeCodexMcpConfig } from "./mcp-config.js";
@@ -332,6 +333,9 @@ ${kleur.bold("명령어:")}
   ${kleur.cyan("mimi-seed init")}        현재 프로젝트를 Mimi Seed에 연결
   ${kleur.cyan("mimi-seed status")}      연결 상태 + 등록 앱 목록
   ${kleur.cyan("mimi-seed auth")}        로컬 인증 (Google OAuth / App Store / Play / BigQuery)
+  ${kleur.cyan("mimi-seed firebase")}    Firebase 앱 생성·config 다운로드·GA4 링크
+  ${kleur.cyan("mimi-seed admob")}       AdMob 계정·앱·광고단위 조회 및 생성
+  ${kleur.cyan("mimi-seed ga4")}         GA4 property·data stream 생성·조회
   ${kleur.cyan("mimi-seed doctor")}      환경 진단 (토큰·Git·프로젝트·CI 체크)
   ${kleur.cyan("mimi-seed check")}       출시 전 Readiness 점검
   ${kleur.cyan("mimi-seed notes")}       릴리즈 노트 생성 (git log → AI → 마켓 적용)
@@ -381,6 +385,15 @@ async function main(): Promise<void> {
         break;
       case "auth":
         await cmdAuth(restArgs);
+        break;
+      case "firebase":
+        await cmdFirebase(restArgs);
+        break;
+      case "admob":
+        await cmdAdmob(restArgs);
+        break;
+      case "ga4":
+        await cmdGa4(restArgs);
         break;
       case "deploy":
         await cmdDeploy(restArgs);

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.3.40",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.3.40",
+      "version": "0.4.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -8,7 +8,10 @@
     "mimi-seed-auth": "dist/auth/cli.js",
     "mimi-seed-appstore-auth": "dist/appstore/setup-cli.js",
     "mimi-seed-playstore-auth": "dist/auth/playstore-setup-cli.js",
-    "mimi-seed-bigquery-auth": "dist/auth/bigquery-setup-cli.js"
+    "mimi-seed-bigquery-auth": "dist/auth/bigquery-setup-cli.js",
+    "mimi-seed-firebase": "dist/firebase/cli.js",
+    "mimi-seed-admob": "dist/admob/cli.js",
+    "mimi-seed-ga4": "dist/ga4/cli.js"
   },
   "files": [
     "dist",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.3.40",
+  "version": "0.4.0",
   "description": "Mimi Seed MCP server — Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/__tests__/admob-tools.test.ts
+++ b/packages/mcp-server/src/__tests__/admob-tools.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { adTypesForFormat } from '../admob/tools.js';
+
+describe('adTypesForFormat', () => {
+  it('동영상 지원 포맷은 RICH_MEDIA + VIDEO', () => {
+    for (const f of ['INTERSTITIAL', 'REWARDED', 'APP_OPEN'] as const) {
+      expect(adTypesForFormat(f)).toEqual(['RICH_MEDIA', 'VIDEO']);
+    }
+  });
+
+  it('REWARDED_INTERSTITIAL 은 video-only (문서상)', () => {
+    expect(adTypesForFormat('REWARDED_INTERSTITIAL')).toEqual(['VIDEO']);
+  });
+
+  it('배너/네이티브는 RICH_MEDIA 만', () => {
+    expect(adTypesForFormat('BANNER')).toEqual(['RICH_MEDIA']);
+    expect(adTypesForFormat('NATIVE')).toEqual(['RICH_MEDIA']);
+  });
+
+  it("'DISPLAY' 같은 무효 enum 을 내지 않는다 (RICH_MEDIA/VIDEO 만 허용)", () => {
+    const valid = new Set(['RICH_MEDIA', 'VIDEO']);
+    for (const f of ['BANNER', 'INTERSTITIAL', 'REWARDED', 'REWARDED_INTERSTITIAL', 'APP_OPEN', 'NATIVE'] as const) {
+      for (const t of adTypesForFormat(f)) expect(valid.has(t)).toBe(true);
+    }
+  });
+});

--- a/packages/mcp-server/src/__tests__/ga4-tools.test.ts
+++ b/packages/mcp-server/src/__tests__/ga4-tools.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeAccountName,
+  normalizePropertyName,
+  buildDataStreamBody,
+  flattenDataStream,
+} from '../ga4/tools.js';
+
+describe('GA4 path normalization', () => {
+  it('bare ID 에 리소스 접두어를 붙인다', () => {
+    expect(normalizeAccountName('123')).toBe('accounts/123');
+    expect(normalizePropertyName('456')).toBe('properties/456');
+  });
+
+  it('이미 접두어가 있으면 그대로 둔다', () => {
+    expect(normalizeAccountName('accounts/123')).toBe('accounts/123');
+    expect(normalizePropertyName('properties/456')).toBe('properties/456');
+  });
+
+  it('공백을 trim 한다', () => {
+    expect(normalizeAccountName('  789 ')).toBe('accounts/789');
+    expect(normalizePropertyName(' 1011 ')).toBe('properties/1011');
+  });
+});
+
+describe('buildDataStreamBody', () => {
+  it('web → WEB_DATA_STREAM + webStreamData.defaultUri', () => {
+    expect(
+      buildDataStreamBody({ platform: 'web', displayName: 'Web', defaultUri: 'https://x.com' }),
+    ).toEqual({
+      type: 'WEB_DATA_STREAM',
+      displayName: 'Web',
+      webStreamData: { defaultUri: 'https://x.com' },
+    });
+  });
+
+  it('android → ANDROID_APP_DATA_STREAM + packageName', () => {
+    expect(
+      buildDataStreamBody({ platform: 'android', displayName: 'A', packageName: 'com.x.y' }),
+    ).toEqual({
+      type: 'ANDROID_APP_DATA_STREAM',
+      displayName: 'A',
+      androidAppStreamData: { packageName: 'com.x.y' },
+    });
+  });
+
+  it('ios → IOS_APP_DATA_STREAM + bundleId', () => {
+    expect(
+      buildDataStreamBody({ platform: 'ios', displayName: 'I', bundleId: 'com.x.y' }),
+    ).toEqual({
+      type: 'IOS_APP_DATA_STREAM',
+      displayName: 'I',
+      iosAppStreamData: { bundleId: 'com.x.y' },
+    });
+  });
+});
+
+describe('flattenDataStream', () => {
+  it('web stream 은 measurementId 를 끌어낸다', () => {
+    const f = flattenDataStream({
+      name: 'properties/1/dataStreams/2',
+      type: 'WEB_DATA_STREAM',
+      displayName: 'Web',
+      webStreamData: { measurementId: 'G-ABC123', defaultUri: 'https://x.com' },
+    });
+    expect(f.measurementId).toBe('G-ABC123');
+    expect(f.firebaseAppId).toBeNull();
+  });
+
+  it('app stream 은 firebaseAppId 를 끌어낸다 (android/ios 공통)', () => {
+    expect(
+      flattenDataStream({ type: 'ANDROID_APP_DATA_STREAM', androidAppStreamData: { firebaseAppId: '1:a:android:b' } })
+        .firebaseAppId,
+    ).toBe('1:a:android:b');
+    expect(
+      flattenDataStream({ type: 'IOS_APP_DATA_STREAM', iosAppStreamData: { firebaseAppId: '1:a:ios:b' } })
+        .firebaseAppId,
+    ).toBe('1:a:ios:b');
+  });
+
+  it('누락 필드는 null 로 안전 처리', () => {
+    expect(flattenDataStream({})).toEqual({
+      name: null,
+      type: null,
+      displayName: null,
+      measurementId: null,
+      firebaseAppId: null,
+    });
+  });
+});

--- a/packages/mcp-server/src/admob/cli.ts
+++ b/packages/mcp-server/src/admob/cli.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// mimi-seed-admob — AdMob sub-CLI (계정/앱/광고단위 조회 + v1beta 생성).
+// 사용자 진입점은 `mimi-seed admob <subcommand>`.
+// ⚠️ create-* 는 AdMob v1beta(Limited Access)라 계정 allowlist 미승인 시 403 → 콘솔 수동 폴백.
+import { requireAuth } from '../helpers.js';
+import * as admob from './tools.js';
+import { runDomainCli, requireFlag, flag, CliUsageError } from '../lib/cli-args.js';
+
+const HELP = `
+  💰 mimi-seed-admob — AdMob attach
+
+  사용법:
+    mimi-seed admob accounts
+        AdMob 계정 목록 (accountId 확인 — accounts/pub-XXXX)
+
+    mimi-seed admob apps --account <id>
+    mimi-seed admob ad-units --account <id>
+        등록된 앱 / 광고 단위 목록
+
+    mimi-seed admob create-app --account <id> --platform <ANDROID|IOS> --name <displayName>
+                               [--store-id com.x.y | 123456789]
+        앱 등록 (store-id 주면 스토어 링크). ⚠️ v1beta Limited Access — 403 가능
+
+    mimi-seed admob create-ad-unit --account <id> --app <appId> --name <name>
+                                   --format <BANNER|INTERSTITIAL|REWARDED|REWARDED_INTERSTITIAL|APP_OPEN|NATIVE>
+        광고 단위 생성. ⚠️ v1beta Limited Access — 403 가능
+
+  인증: npx -y @yoonion/mimi-seed-mcp mimi-seed-auth
+`;
+
+const AD_FORMATS = ['BANNER', 'INTERSTITIAL', 'REWARDED', 'REWARDED_INTERSTITIAL', 'APP_OPEN', 'NATIVE'];
+
+runDomainCli({
+  binName: 'mimi-seed-admob',
+  argv: process.argv.slice(2),
+  help: HELP,
+  handlers: {
+    accounts: async () => admob.listAccounts(await requireAuth()),
+    apps: async (p) => admob.listApps(await requireAuth(), requireFlag(p, 'account')),
+    'ad-units': async (p) => admob.listAdUnits(await requireAuth(), requireFlag(p, 'account')),
+    'create-app': async (p) => {
+      const platform = requireFlag(p, 'platform').toUpperCase();
+      if (platform !== 'ANDROID' && platform !== 'IOS') {
+        throw new CliUsageError('--platform 은 ANDROID | IOS 여야 합니다.');
+      }
+      return admob.createApp(
+        await requireAuth(),
+        requireFlag(p, 'account'),
+        platform,
+        requireFlag(p, 'name'),
+        flag(p, 'store-id'),
+      );
+    },
+    'create-ad-unit': async (p) => {
+      const format = requireFlag(p, 'format').toUpperCase();
+      if (!AD_FORMATS.includes(format)) {
+        throw new CliUsageError(`--format 은 ${AD_FORMATS.join(' | ')} 중 하나여야 합니다.`);
+      }
+      return admob.createAdUnit(
+        await requireAuth(),
+        requireFlag(p, 'account'),
+        requireFlag(p, 'app'),
+        requireFlag(p, 'name'),
+        format as admob.AdFormat,
+      );
+    },
+  },
+});

--- a/packages/mcp-server/src/admob/tools.ts
+++ b/packages/mcp-server/src/admob/tools.ts
@@ -115,21 +115,56 @@ export async function getTodayEarnings(auth: OAuth2Client, accountId: string) {
 
 // ─── v1beta: 앱 생성 (Limited Access) ───
 
+export type AdFormat =
+  | 'BANNER'
+  | 'INTERSTITIAL'
+  | 'REWARDED'
+  | 'REWARDED_INTERSTITIAL'
+  | 'APP_OPEN'
+  | 'NATIVE';
+
+/**
+ * adFormat → adTypes 파생 (순수 함수 — 테스트 대상).
+ * AdMob v1beta adTypes 의 유효값은 'RICH_MEDIA'(텍스트·이미지 등 비동영상)와 'VIDEO' 둘뿐
+ * (Schema$AdUnit.adTypes 문서). 동영상 지원 포맷은 VIDEO 를 포함하고,
+ * REWARDED_INTERSTITIAL 은 문서상 video-only 다.
+ */
+export function adTypesForFormat(adFormat: AdFormat): string[] {
+  switch (adFormat) {
+    case 'INTERSTITIAL':
+    case 'REWARDED':
+    case 'APP_OPEN':
+      return ['RICH_MEDIA', 'VIDEO'];
+    case 'REWARDED_INTERSTITIAL':
+      return ['VIDEO'];
+    case 'BANNER':
+    case 'NATIVE':
+    default:
+      return ['RICH_MEDIA'];
+  }
+}
+
 export async function createApp(
   auth: OAuth2Client,
   accountId: string,
   platform: 'ANDROID' | 'IOS',
   displayName: string,
+  /** 스토어에 게시된 앱이면 store ID 로 링크 (Android=패키지명, iOS=App Store 숫자 ID). 없으면 manual(unlinked) 앱. */
+  appStoreId?: string,
 ) {
   // v1beta — 대부분 계정에서 403. Google Account Manager 승인 필요.
   const admobBeta = google.admob('v1beta' as any) as any;
+  const requestBody: Record<string, unknown> = { platform };
+  // manualAppInfo.displayName 은 writable(사용자 제공, AdMob UI 표시명) — linking 후에도 유지된다.
+  // linkedAppInfo.displayName 은 output-only(스토어 표시명)라 보내도 무시되므로, store 링크엔 appStoreId 만 넣는다.
+  requestBody.manualAppInfo = { displayName };
+  if (appStoreId) {
+    requestBody.linkedAppInfo = { appStoreId };
+  }
   const res = await admobBeta.accounts.apps.create({
     auth,
     parent: accountId,
-    requestBody: {
-      platform,
-      manualAppInfo: { displayName },
-    },
+    requestBody,
   });
   return res.data;
 }
@@ -141,7 +176,7 @@ export async function createAdUnit(
   accountId: string,
   appId: string,
   displayName: string,
-  adFormat: 'BANNER' | 'INTERSTITIAL' | 'REWARDED' | 'REWARDED_INTERSTITIAL' | 'APP_OPEN' | 'NATIVE',
+  adFormat: AdFormat,
 ) {
   const admobBeta = google.admob('v1beta' as any) as any;
   const res = await admobBeta.accounts.adUnits.create({
@@ -151,7 +186,7 @@ export async function createAdUnit(
       appId,
       displayName,
       adFormat,
-      adTypes: ['DISPLAY'],
+      adTypes: adTypesForFormat(adFormat),
     },
   });
   return res.data;

--- a/packages/mcp-server/src/auth/errors.ts
+++ b/packages/mcp-server/src/auth/errors.ts
@@ -11,6 +11,7 @@ export type AuthErrorCode =
   | 'UNAUTHORIZED_CLIENT' // 동의 범위/리다이렉트 URI 불일치
   | 'REFRESH_NETWORK_ERROR' // 구글 토큰 엔드포인트 도달 실패
   | 'REFRESH_UNKNOWN' // 분류 안 된 갱신 오류
+  | 'INSUFFICIENT_SCOPE' // 토큰은 유효하나 도구가 요구하는 OAuth 스코프 미보유 (신규 스코프 추가 후 재로그인 전)
   // 로그인 플로우
   | 'CALLBACK_PORT_IN_USE' // 9876 점유
   | 'CALLBACK_TIMEOUT' // 사용자가 시간 내 승인 안 함

--- a/packages/mcp-server/src/auth/google-auth.ts
+++ b/packages/mcp-server/src/auth/google-auth.ts
@@ -15,6 +15,7 @@ const SCOPES = [
   'https://www.googleapis.com/auth/androidpublisher',
   'https://www.googleapis.com/auth/adwords', // Google Ads API (googleads_* tools)
   'https://www.googleapis.com/auth/webmasters', // Search Console API (gsc_* tools, 사이트맵 제출 포함)
+  'https://www.googleapis.com/auth/analytics.edit', // GA4 Analytics Admin API (ga4_* tools — property/data stream 생성·조회)
 ];
 
 // Primary config dir. Legacy `~/.preseed` is read as a fallback during the
@@ -35,6 +36,8 @@ export interface StoredTokens {
   refresh_token: string;
   token_type: string;
   expiry_date: number;
+  /** 공백 구분 부여 스코프. 신규 도구(GA4 등) pre-flight 스코프 검사에 사용. 구 토큰은 undefined. */
+  scope?: string;
 }
 
 function ensureDir() {
@@ -125,6 +128,7 @@ export function getAuthenticatedClient(): ReturnType<typeof createOAuth2Client> 
         ...(newTokens.access_token && { access_token: newTokens.access_token }),
         ...(newTokens.refresh_token && { refresh_token: newTokens.refresh_token }),
         ...(newTokens.expiry_date && { expiry_date: newTokens.expiry_date }),
+        ...(newTokens.scope && { scope: newTokens.scope }),
       });
     }
   });
@@ -218,6 +222,7 @@ export function startAuth(
           refresh_token: tokens.refresh_token,
           token_type: tokens.token_type ?? 'Bearer',
           expiry_date: tokens.expiry_date ?? Date.now() + 3600_000,
+          ...(tokens.scope && { scope: tokens.scope }),
         };
         saveTokens(stored);
 
@@ -347,6 +352,8 @@ export async function ensureFreshAccessToken(marginMs = 300_000): Promise<Refres
       refresh_token: credentials.refresh_token ?? tokens.refresh_token,
       token_type: credentials.token_type ?? tokens.token_type ?? 'Bearer',
       expiry_date: credentials.expiry_date ?? Date.now() + 3600_000,
+      // refresh 응답은 scope 를 생략할 수 있으므로 기존 값을 보존(blank 방지).
+      scope: credentials.scope ?? tokens.scope,
     };
     saveTokens(refreshed);
     return {

--- a/packages/mcp-server/src/firebase/cli.ts
+++ b/packages/mcp-server/src/firebase/cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// mimi-seed-firebase — Firebase 프로비저닝 sub-CLI (프로젝트/앱 조회·생성, config 다운로드, GA4 링크).
+// 사용자 진입점은 `mimi-seed firebase <subcommand>`.
+import { requireAuth } from '../helpers.js';
+import * as firebase from './tools.js';
+import { runDomainCli, requireFlag, flag, CliUsageError } from '../lib/cli-args.js';
+
+const FB_PLATFORMS = ['android', 'ios', 'web'];
+
+const HELP = `
+  🔥 mimi-seed-firebase — Firebase attach (프로비저닝 + config 산출)
+
+  사용법:
+    mimi-seed firebase projects
+        내 Firebase 프로젝트 목록
+
+    mimi-seed firebase apps --project <id> [--platform android|ios|web]
+        프로젝트의 앱 목록 (기본: android+ios+web 전부)
+
+    mimi-seed firebase create-android --project <id> --package com.x.y --name <displayName>
+    mimi-seed firebase create-ios     --project <id> --bundle com.x.y  --name <displayName>
+        새 앱 등록
+
+    mimi-seed firebase config --project <id> --app <appId> --platform <android|ios|web>
+        ⭐ google-services.json / GoogleService-Info.plist / web config 출력 (attach 페이로드)
+
+    mimi-seed firebase enable-services --project <id>
+        Firebase 기본 서비스 일괄 활성화 (Analytics 포함)
+
+    mimi-seed firebase link-analytics --project <id> (--account <gaAccountId> | --property <gaPropertyId>)
+        GA4 링크 (앱 measurement 자동 활성화) — account(신규 property 생성) 또는 property(기존 연결) 중 하나 필수
+
+    mimi-seed firebase analytics-details --project <id>
+        GA4 링크 상세 (property + stream 매핑)
+
+  인증: npx -y @yoonion/mimi-seed-mcp mimi-seed-auth
+`;
+
+async function listApps(projectId: string, platform?: string) {
+  const auth = await requireAuth();
+  // platform 이 지정됐는데 알 수 없는 값이면 조용히 'all' 로 떨어지지 않고 명시적으로 거부.
+  if (platform !== undefined && !FB_PLATFORMS.includes(platform)) {
+    throw new CliUsageError('--platform 은 android | ios | web 중 하나여야 합니다.');
+  }
+  if (platform === 'android') return firebase.listAndroidApps(auth, projectId);
+  if (platform === 'ios') return firebase.listIosApps(auth, projectId);
+  if (platform === 'web') return firebase.listWebApps(auth, projectId);
+  const [android, ios, web] = await Promise.all([
+    firebase.listAndroidApps(auth, projectId),
+    firebase.listIosApps(auth, projectId),
+    firebase.listWebApps(auth, projectId),
+  ]);
+  return { android, ios, web };
+}
+
+async function getConfig(projectId: string, appId: string, platform: string) {
+  const auth = await requireAuth();
+  if (platform === 'android') return firebase.getAndroidConfig(auth, projectId, appId);
+  if (platform === 'ios') return firebase.getIosConfig(auth, projectId, appId);
+  if (platform === 'web') return firebase.getWebConfig(auth, projectId, appId);
+  throw new CliUsageError('--platform 은 android | ios | web 중 하나여야 합니다.');
+}
+
+runDomainCli({
+  binName: 'mimi-seed-firebase',
+  argv: process.argv.slice(2),
+  help: HELP,
+  handlers: {
+    projects: async () => firebase.listProjects(await requireAuth()),
+    apps: async (p) => listApps(requireFlag(p, 'project'), flag(p, 'platform')?.toLowerCase()),
+    'create-android': async (p) =>
+      firebase.createAndroidApp(
+        await requireAuth(),
+        requireFlag(p, 'project'),
+        requireFlag(p, 'package'),
+        requireFlag(p, 'name'),
+      ),
+    'create-ios': async (p) =>
+      firebase.createIosApp(
+        await requireAuth(),
+        requireFlag(p, 'project'),
+        requireFlag(p, 'bundle'),
+        requireFlag(p, 'name'),
+      ),
+    config: async (p) =>
+      getConfig(requireFlag(p, 'project'), requireFlag(p, 'app'), requireFlag(p, 'platform').toLowerCase()),
+    'enable-services': async (p) =>
+      firebase.enableCommonServices(await requireAuth(), requireFlag(p, 'project')),
+    'link-analytics': async (p) =>
+      firebase.linkAnalytics(await requireAuth(), requireFlag(p, 'project'), {
+        analyticsAccountId: flag(p, 'account'),
+        analyticsPropertyId: flag(p, 'property'),
+      }),
+    'analytics-details': async (p) =>
+      firebase.getAnalyticsDetails(await requireAuth(), requireFlag(p, 'project')),
+  },
+});

--- a/packages/mcp-server/src/firebase/tools.ts
+++ b/packages/mcp-server/src/firebase/tools.ts
@@ -196,6 +196,46 @@ export async function listEnabledServices(auth: OAuth2Client, projectId: string)
   }));
 }
 
+// ─── Google Analytics(GA4) 링크 ───
+
+/**
+ * Firebase 프로젝트에 Google Analytics(GA4)를 링크한다.
+ * - analyticsAccountId: 그 GA 계정 하위에 GA4 property 를 새로 만들어 링크.
+ * - analyticsPropertyId: 기존 GA4 property 에 링크.
+ * 둘 중 정확히 하나는 필수다(addGoogleAnalytics API 계약 — 무인자 모드 없음).
+ * 앱별 data stream(android/ios measurement)은 링크 후 Firebase 가 자동 생성한다.
+ * (반환값은 long-running Operation — 완료까지 수 초 소요될 수 있음.)
+ */
+export async function linkAnalytics(
+  auth: OAuth2Client,
+  projectId: string,
+  opts: { analyticsAccountId?: string; analyticsPropertyId?: string } = {},
+) {
+  const requestBody: { analyticsAccountId?: string; analyticsPropertyId?: string } = {};
+  if (opts.analyticsAccountId) requestBody.analyticsAccountId = opts.analyticsAccountId;
+  if (opts.analyticsPropertyId) requestBody.analyticsPropertyId = opts.analyticsPropertyId;
+  if (!requestBody.analyticsAccountId && !requestBody.analyticsPropertyId) {
+    throw new Error(
+      'GA4 링크엔 analyticsAccountId(신규 property 생성) 또는 analyticsPropertyId(기존 property 연결) 중 하나가 필요합니다.',
+    );
+  }
+  const res = await google.firebase('v1beta1').projects.addGoogleAnalytics({
+    auth,
+    parent: `projects/${projectId}`,
+    requestBody,
+  });
+  return res.data;
+}
+
+/** 프로젝트의 GA4 링크 상세 — 연결된 analyticsProperty + 앱↔stream 매핑 조회. */
+export async function getAnalyticsDetails(auth: OAuth2Client, projectId: string) {
+  const res = await google.firebase('v1beta1').projects.getAnalyticsDetails({
+    auth,
+    name: `projects/${projectId}/analyticsDetails`,
+  });
+  return res.data;
+}
+
 // ─── 편의 함수 ───
 
 const COMMON_SERVICES = [
@@ -206,6 +246,7 @@ const COMMON_SERVICES = [
   'fcm.googleapis.com',
   'identitytoolkit.googleapis.com',
   'cloudresourcemanager.googleapis.com',
+  'firebaseanalytics.googleapis.com', // GA4(Firebase Analytics) — linkAnalytics 전에 활성화
 ];
 
 export async function enableCommonServices(auth: OAuth2Client, projectId: string) {

--- a/packages/mcp-server/src/ga4/cli.ts
+++ b/packages/mcp-server/src/ga4/cli.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// mimi-seed-ga4 — GA4 Analytics Admin/Data API sub-CLI.
+// 사용자 진입점은 `mimi-seed ga4 <subcommand>` (cli 패키지가 npx 로 이 bin 을 호출).
+import { requireAuth } from '../helpers.js';
+import * as ga4 from './tools.js';
+import { runDomainCli, requireFlag, flag, flagList } from '../lib/cli-args.js';
+
+const HELP = `
+  📊 mimi-seed-ga4 — GA4(Google Analytics 4) attach
+
+  사용법:
+    mimi-seed ga4 accounts
+        접근 가능한 GA 계정 + property 요약 (accountId/propertyId 확인)
+
+    mimi-seed ga4 properties --account <id>
+        계정 하위 GA4 property 목록
+
+    mimi-seed ga4 create-property --account <id> --name <displayName>
+                                  [--timezone Asia/Seoul] [--currency KRW]
+        새 GA4 property 생성
+
+    mimi-seed ga4 create-stream --property <id> --platform <web|android|ios> --name <name>
+                                [--uri https://...] [--package com.x.y] [--bundle com.x.y]
+        data stream 생성 (web→measurementId, app→firebaseAppId)
+
+    mimi-seed ga4 streams --property <id>
+        data stream 목록
+
+    mimi-seed ga4 report --property <id> --start 28daysAgo --end today
+                         [--dimensions date,country] [--metrics activeUsers,eventCount]
+        GA4 Data API 리포트
+
+  ⚠️ analytics.edit 스코프 필요 — 처음이면 재로그인:
+     npx -y @yoonion/mimi-seed-mcp mimi-seed-auth
+`;
+
+runDomainCli({
+  binName: 'mimi-seed-ga4',
+  argv: process.argv.slice(2),
+  help: HELP,
+  handlers: {
+    accounts: async () => ga4.listAccountSummaries(await requireAuth(ga4.GA4_SCOPE)),
+    properties: async (p) => ga4.listProperties(await requireAuth(ga4.GA4_SCOPE), requireFlag(p, 'account')),
+    'create-property': async (p) =>
+      ga4.createProperty(await requireAuth(ga4.GA4_SCOPE), {
+        accountId: requireFlag(p, 'account'),
+        displayName: requireFlag(p, 'name'),
+        timeZone: flag(p, 'timezone'),
+        currencyCode: flag(p, 'currency'),
+      }),
+    'create-stream': async (p) =>
+      ga4.createDataStream(await requireAuth(ga4.GA4_SCOPE), requireFlag(p, 'property'), {
+        platform: requireFlag(p, 'platform') as ga4.DataStreamPlatform,
+        displayName: requireFlag(p, 'name'),
+        defaultUri: flag(p, 'uri'),
+        packageName: flag(p, 'package'),
+        bundleId: flag(p, 'bundle'),
+      }),
+    streams: async (p) => ga4.listDataStreams(await requireAuth(ga4.GA4_SCOPE), requireFlag(p, 'property')),
+    report: async (p) =>
+      ga4.runReport(await requireAuth(ga4.GA4_SCOPE), requireFlag(p, 'property'), {
+        startDate: requireFlag(p, 'start'),
+        endDate: requireFlag(p, 'end'),
+        dimensions: flagList(p, 'dimensions'),
+        metrics: flagList(p, 'metrics'),
+      }),
+  },
+});

--- a/packages/mcp-server/src/ga4/tools.ts
+++ b/packages/mcp-server/src/ga4/tools.ts
@@ -1,0 +1,175 @@
+import { google } from 'googleapis';
+import type { OAuth2Client } from 'google-auth-library';
+
+/**
+ * Google Analytics 4 — Admin API(v1beta) + Data API(v1beta) 래퍼.
+ *
+ * Admin API 로 GA4 property/data stream 을 직접 생성·조회한다. Firebase Analytics 를
+ * enable 하면 GA4 property 가 자동 생성되지만, 그 경로는 property 이름/타임존/통화나
+ * web data stream(measurement ID, G-XXXX) 을 제어할 수 없다. 풀 컨트롤이 필요하면 이 모듈을 쓴다.
+ *
+ * 인증은 mimi-seed OAuth 클라이언트(`requireAuth()`)를 그대로 사용 — `analytics.edit` 스코프 필요.
+ * (스코프 추가 후 기존 사용자는 1회 재로그인: `npx -y @yoonion/mimi-seed-mcp mimi-seed-auth`)
+ */
+const admin = () => google.analyticsadmin('v1beta');
+const data = () => google.analyticsdata('v1beta');
+
+/** GA4 도구가 요구하는 OAuth 스코프 — requireAuth() pre-flight 검사에 사용. */
+export const GA4_SCOPE = 'https://www.googleapis.com/auth/analytics.edit';
+
+export type Ga4Auth = OAuth2Client;
+
+export type DataStreamPlatform = 'web' | 'android' | 'ios';
+
+// ─── 경로 정규화 (순수 함수 — 테스트 대상) ───
+
+/** '123' | 'accounts/123' → 'accounts/123' */
+export function normalizeAccountName(accountId: string): string {
+  const id = accountId.trim();
+  return id.startsWith('accounts/') ? id : `accounts/${id}`;
+}
+
+/** '123' | 'properties/123' → 'properties/123' */
+export function normalizePropertyName(propertyId: string): string {
+  const id = propertyId.trim();
+  return id.startsWith('properties/') ? id : `properties/${id}`;
+}
+
+/**
+ * dataStreams.create 응답에서 클라이언트가 실제로 필요로 하는 식별자를 평탄화한다.
+ * - web stream → measurementId (G-XXXX, gtag/web 연동용)
+ * - app stream → firebaseAppId (Firebase 앱과 자동 링크된 경우)
+ */
+export function flattenDataStream(d: {
+  name?: string | null;
+  type?: string | null;
+  displayName?: string | null;
+  webStreamData?: { measurementId?: string | null; defaultUri?: string | null } | null;
+  androidAppStreamData?: { firebaseAppId?: string | null; packageName?: string | null } | null;
+  iosAppStreamData?: { firebaseAppId?: string | null; bundleId?: string | null } | null;
+}) {
+  return {
+    name: d.name ?? null,
+    type: d.type ?? null,
+    displayName: d.displayName ?? null,
+    measurementId: d.webStreamData?.measurementId ?? null,
+    firebaseAppId:
+      d.androidAppStreamData?.firebaseAppId ?? d.iosAppStreamData?.firebaseAppId ?? null,
+  };
+}
+
+/** data stream 생성 요청 본문 조립 (순수 함수 — 테스트 대상). */
+export function buildDataStreamBody(opts: {
+  platform: DataStreamPlatform;
+  displayName: string;
+  defaultUri?: string;
+  packageName?: string;
+  bundleId?: string;
+}) {
+  switch (opts.platform) {
+    case 'web':
+      return {
+        type: 'WEB_DATA_STREAM',
+        displayName: opts.displayName,
+        webStreamData: { defaultUri: opts.defaultUri },
+      };
+    case 'android':
+      return {
+        type: 'ANDROID_APP_DATA_STREAM',
+        displayName: opts.displayName,
+        androidAppStreamData: { packageName: opts.packageName },
+      };
+    case 'ios':
+      return {
+        type: 'IOS_APP_DATA_STREAM',
+        displayName: opts.displayName,
+        iosAppStreamData: { bundleId: opts.bundleId },
+      };
+  }
+}
+
+// ─── 계정/속성 디스커버리 ───
+
+/** 접근 가능한 GA 계정 + 각 계정의 property 요약. accountId/propertyId 를 찾는 시작점. */
+export async function listAccountSummaries(auth: Ga4Auth) {
+  const res = await admin().accountSummaries.list({ auth, pageSize: 200 });
+  return res.data.accountSummaries ?? [];
+}
+
+/** 계정 하위 GA4 property 목록. accountId: '123' 또는 'accounts/123'. */
+export async function listProperties(auth: Ga4Auth, accountId: string) {
+  const res = await admin().properties.list({
+    auth,
+    filter: `parent:${normalizeAccountName(accountId)}`,
+    pageSize: 200,
+  });
+  return res.data.properties ?? [];
+}
+
+// ─── property / data stream 생성 (attach 핵심) ───
+
+export async function createProperty(
+  auth: Ga4Auth,
+  opts: { accountId: string; displayName: string; timeZone?: string; currencyCode?: string },
+) {
+  const res = await admin().properties.create({
+    auth,
+    requestBody: {
+      parent: normalizeAccountName(opts.accountId),
+      displayName: opts.displayName,
+      timeZone: opts.timeZone ?? 'America/Los_Angeles',
+      currencyCode: opts.currencyCode ?? 'USD',
+    },
+  });
+  return res.data; // { name: 'properties/XXXX', displayName, ... }
+}
+
+export async function createDataStream(
+  auth: Ga4Auth,
+  propertyId: string,
+  opts: {
+    platform: DataStreamPlatform;
+    displayName: string;
+    defaultUri?: string;
+    packageName?: string;
+    bundleId?: string;
+  },
+) {
+  const res = await admin().properties.dataStreams.create({
+    auth,
+    parent: normalizePropertyName(propertyId),
+    requestBody: buildDataStreamBody(opts),
+  });
+  return { ...flattenDataStream(res.data), raw: res.data };
+}
+
+export async function listDataStreams(auth: Ga4Auth, propertyId: string) {
+  const res = await admin().properties.dataStreams.list({
+    auth,
+    parent: normalizePropertyName(propertyId),
+    pageSize: 200,
+  });
+  return (res.data.dataStreams ?? []).map((d) => flattenDataStream(d));
+}
+
+// ─── 리포트 (Data API) ───
+
+export interface RunReportParams {
+  startDate: string;
+  endDate: string;
+  dimensions?: string[];
+  metrics?: string[];
+}
+
+export async function runReport(auth: Ga4Auth, propertyId: string, params: RunReportParams) {
+  const res = await data().properties.runReport({
+    auth,
+    property: normalizePropertyName(propertyId),
+    requestBody: {
+      dateRanges: [{ startDate: params.startDate, endDate: params.endDate }],
+      dimensions: (params.dimensions ?? []).map((name) => ({ name })),
+      metrics: (params.metrics ?? ['activeUsers', 'eventCount']).map((name) => ({ name })),
+    },
+  });
+  return res.data;
+}

--- a/packages/mcp-server/src/helpers.ts
+++ b/packages/mcp-server/src/helpers.ts
@@ -1,4 +1,4 @@
-import { getAuthenticatedClient, ensureFreshAccessToken } from './auth/google-auth.js';
+import { getAuthenticatedClient, ensureFreshAccessToken, getStoredTokens } from './auth/google-auth.js';
 import { getServiceAccountClient, getServiceAccountJson } from './auth/playstore-auth.js';
 import { getAppStoreCredentials } from './appstore/auth.js';
 import type { AuthErrorPayload } from './auth/errors.js';
@@ -27,7 +27,7 @@ function formatAuthError(p: AuthErrorPayload): string {
  * 기존엔 만료 시 각 OAuth 도구(firebase/admob/iam/googleads/checks)가
  * googleapis GaxiosError 를 그대로 노출 → 사용자는 "재로그인하라"는 안내를 못 받았다.
  */
-export async function requireAuth() {
+export async function requireAuth(requiredScope?: string) {
   const result = await ensureFreshAccessToken();
   if (result.status === 'unauthenticated' || result.status === 'expired_refresh_failed') {
     throw new Error(formatAuthError(result.error));
@@ -43,6 +43,24 @@ export async function requireAuth() {
         needsReauth: true,
       }),
     );
+  }
+  // 신규 스코프(GA4 analytics.edit 등)는 변경 전 발급된 토큰엔 없다. expiry 만 보는
+  // ensureFreshAccessToken 은 이를 못 걸러내므로(런타임 ACCESS_TOKEN_SCOPE_INSUFFICIENT),
+  // 저장된 scope 로 pre-flight 검사해 결정적인 재로그인 안내를 던진다.
+  // (scope 가 undefined 인 구 토큰은 미보유로 간주 → 재로그인 유도.)
+  if (requiredScope) {
+    const granted = (getStoredTokens()?.scope ?? '').split(' ').filter(Boolean);
+    if (!granted.includes(requiredScope)) {
+      throw new Error(
+        formatAuthError({
+          code: 'INSUFFICIENT_SCOPE',
+          message: `이 도구는 추가 권한이 필요해 (${requiredScope}). 기존 로그인에 없어서 1회 재로그인이 필요해.`,
+          hint: 'mimi-seed-auth 로 재로그인하면 새 권한이 부여돼.',
+          retriable: false,
+          needsReauth: true,
+        }),
+      );
+    }
   }
   return client;
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -16,6 +16,7 @@ import { registerInstagramTools } from './registers/instagram.js';
 import { registerFacebookTools } from './registers/facebook.js';
 import { registerGoogleAdsTools } from './registers/googleads.js';
 import { registerGscTools } from './registers/gsc.js';
+import { registerGa4Tools } from './registers/ga4.js';
 import { registerJenkinsTools } from './registers/jenkins.js';
 import { registerAndroidTools } from './registers/android.js';
 import { registerPrompts } from './prompts.js';
@@ -46,6 +47,7 @@ registerInstagramTools(server);
 registerFacebookTools(server);
 registerGoogleAdsTools(server);
 registerGscTools(server);
+registerGa4Tools(server);
 registerJenkinsTools(server);
 registerAndroidTools(server);
 registerPrompts(server);
@@ -60,6 +62,9 @@ const SUBCOMMANDS: Record<string, () => Promise<unknown>> = {
   'mimi-seed-playstore-auth': () => import('./auth/playstore-setup-cli.js'),
   'mimi-seed-appstore-auth': () => import('./appstore/setup-cli.js'),
   'mimi-seed-bigquery-auth': () => import('./auth/bigquery-setup-cli.js'),
+  'mimi-seed-firebase': () => import('./firebase/cli.js'),
+  'mimi-seed-admob': () => import('./admob/cli.js'),
+  'mimi-seed-ga4': () => import('./ga4/cli.js'),
 };
 
 async function main() {

--- a/packages/mcp-server/src/lib/cli-args.ts
+++ b/packages/mcp-server/src/lib/cli-args.ts
@@ -1,0 +1,117 @@
+// 도메인별 sub-CLI(mimi-seed-firebase / -admob / -ga4)가 공유하는 최소 argv 파서.
+// `mimi-seed <domain> <subcommand> [--flag value] [--bool]` 형태를 파싱한다.
+// 실제 사용자 진입점은 cli 패키지의 `mimi-seed <domain> ...` 이고, 그게 npx 로
+// 이 bin 들을 stdio 그대로 호출한다(auth.ts:runMcpBin 패턴과 동일).
+
+export interface ParsedArgs {
+  /** 첫 위치 인자 — 서브커맨드 (예: 'create-property') */
+  command: string | undefined;
+  /** --name value 형태의 값 플래그 */
+  flags: Record<string, string>;
+  /** --force 형태의 불리언 플래그 */
+  bools: Set<string>;
+}
+
+/** process.argv.slice(2) 같은 토큰 배열을 파싱. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const flags: Record<string, string> = {};
+  const bools = new Set<string>();
+  let command: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i];
+    if (tok.startsWith('--')) {
+      const eq = tok.indexOf('=');
+      if (eq !== -1) {
+        // --key=value — 값이 '--'로 시작해도 안전하게 전달.
+        flags[tok.slice(2, eq)] = tok.slice(eq + 1);
+        continue;
+      }
+      const key = tok.slice(2);
+      const next = argv[i + 1];
+      // 다음 토큰이 또 다른 플래그(--)면 값으로 소비하지 않는다 → 값 누락을 bool 로 기록.
+      if (next !== undefined && !next.startsWith('--')) {
+        flags[key] = next;
+        i++;
+      } else {
+        bools.add(key);
+      }
+    } else if (command === undefined) {
+      command = tok;
+    }
+  }
+
+  return { command, flags, bools };
+}
+
+/** 값 플래그 조회 — 없으면 fallback. */
+export function flag(p: ParsedArgs, name: string, fallback?: string): string | undefined {
+  return p.flags[name] ?? fallback;
+}
+
+/** 필수 값 플래그 — 없으면 친절 에러 throw. */
+export function requireFlag(p: ParsedArgs, name: string): string {
+  const v = p.flags[name];
+  if (v === undefined || v === '') {
+    if (p.bools.has(name)) {
+      throw new CliUsageError(
+        `--${name} 에 값이 필요합니다 (값 없이 단독으로 쓰였습니다). 값이 '--'로 시작하면 --${name}=값 형태로 쓰세요.`,
+      );
+    }
+    throw new CliUsageError(`--${name} 가 필요합니다.`);
+  }
+  return v;
+}
+
+/** 쉼표 구분 값 → 배열 ('a, b ,c' → ['a','b','c']). 없으면 undefined. */
+export function flagList(p: ParsedArgs, name: string): string[] | undefined {
+  const v = p.flags[name];
+  if (!v) return undefined;
+  return v.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+/** 사용법 위반 — main()에서 잡아 도움말과 함께 exit 1. */
+export class CliUsageError extends Error {}
+
+/** 결과 JSON 을 stdout 으로 출력 (stderr 는 진행/안내용). */
+export function printJson(data: unknown): void {
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+}
+
+/**
+ * 도메인 sub-CLI 공통 러너. requireAuth → 핸들러 매핑 실행 → JSON 출력 → exit code.
+ * 핸들러는 ParsedArgs 를 받아 출력할 데이터를 반환한다.
+ */
+export async function runDomainCli(opts: {
+  binName: string;
+  argv: string[];
+  help: string;
+  handlers: Record<string, (p: ParsedArgs) => Promise<unknown>>;
+}): Promise<void> {
+  const p = parseArgs(opts.argv);
+
+  if (!p.command || p.command === 'help' || p.bools.has('help') || p.bools.has('h')) {
+    process.stderr.write(opts.help + '\n');
+    process.exit(p.command ? 0 : 1);
+  }
+
+  const handler = opts.handlers[p.command];
+  if (!handler) {
+    process.stderr.write(`❌ 알 수 없는 서브커맨드: ${p.command}\n\n` + opts.help + '\n');
+    process.exit(1);
+  }
+
+  try {
+    const result = await handler(p);
+    printJson(result);
+    process.exit(0);
+  } catch (e) {
+    if (e instanceof CliUsageError) {
+      process.stderr.write(`❌ ${e.message}\n\n` + opts.help + '\n');
+    } else {
+      process.stderr.write(`❌ ${e instanceof Error ? e.message : String(e)}\n`);
+      if (process.env.DEBUG && e instanceof Error) process.stderr.write((e.stack ?? '') + '\n');
+    }
+    process.exit(1);
+  }
+}

--- a/packages/mcp-server/src/registers/admob.ts
+++ b/packages/mcp-server/src/registers/admob.ts
@@ -73,16 +73,17 @@ export function registerAdmobTools(server: McpServer) {
 
   server.tool(
     'admob_create_app',
-    'AdMob에 새 앱 등록 (v1beta — Limited Access)',
+    'AdMob에 새 앱 등록 (v1beta — Limited Access). appStoreId 를 주면 스토어 게시 앱과 링크(Android=패키지명, iOS=App Store 숫자 ID), 없으면 manual(unlinked) 앱.',
     {
       accountId: z.string().describe('AdMob 계정 ID'),
       platform: z.enum(['ANDROID', 'IOS']).describe('플랫폼'),
       displayName: z.string().describe('앱 이름'),
+      appStoreId: z.string().optional().describe('스토어 링크용 ID — Android는 패키지명(com.x.y), iOS는 App Store 숫자 ID'),
     },
-    async ({ accountId, platform, displayName }) => {
+    async ({ accountId, platform, displayName, appStoreId }) => {
       const auth = await requireAuth();
       try {
-        const result = await admob.createApp(auth, accountId, platform, displayName);
+        const result = await admob.createApp(auth, accountId, platform, displayName, appStoreId);
         return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
       } catch (err: any) {
         if (err.code === 403) {

--- a/packages/mcp-server/src/registers/firebase.ts
+++ b/packages/mcp-server/src/registers/firebase.ts
@@ -246,4 +246,30 @@ export function registerFirebaseTools(server: McpServer) {
       return { content: [{ type: 'text', text: JSON.stringify(services, null, 2) }] };
     },
   );
+
+  server.tool(
+    'firebase_link_analytics',
+    'Firebase 프로젝트에 Google Analytics(GA4) 링크 → 앱별 measurement 자동 활성화. analyticsAccountId(그 계정에 GA4 property 신규 생성) 또는 analyticsPropertyId(기존 property 링크) 중 하나 필수. 먼저 firebase_enable_common_services 로 firebaseanalytics 활성화 권장. property 이름/web stream 까지 직접 제어하려면 ga4_create_property/ga4_create_data_stream 사용.',
+    {
+      projectId: z.string().describe('Firebase 프로젝트 ID'),
+      analyticsAccountId: z.string().optional().describe('GA 계정 ID (신규 property 생성 위치) — 예: 123456'),
+      analyticsPropertyId: z.string().optional().describe('기존 GA4 property ID 에 링크할 경우'),
+    },
+    async ({ projectId, analyticsAccountId, analyticsPropertyId }) => {
+      const auth = await requireAuth();
+      const result = await firebase.linkAnalytics(auth, projectId, { analyticsAccountId, analyticsPropertyId });
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'firebase_get_analytics_details',
+    '프로젝트의 GA4 링크 상세 — 연결된 analyticsProperty + 앱↔data stream 매핑 조회.',
+    { projectId: z.string().describe('Firebase 프로젝트 ID') },
+    async ({ projectId }) => {
+      const auth = await requireAuth();
+      const details = await firebase.getAnalyticsDetails(auth, projectId);
+      return { content: [{ type: 'text', text: JSON.stringify(details, null, 2) }] };
+    },
+  );
 }

--- a/packages/mcp-server/src/registers/ga4.ts
+++ b/packages/mcp-server/src/registers/ga4.ts
@@ -1,0 +1,127 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import * as ga4Raw from '../ga4/tools.js';
+import { requireAuth } from '../helpers.js';
+import { friendlyGoogleError } from '../lib/google-errors.js';
+
+// firebase register 와 동일한 프록시 — raw GaxiosError(SERVICE_DISABLED / 403 /
+// ACCESS_TOKEN_SCOPE_INSUFFICIENT)를 "다음에 뭘 할지" 메시지로 변환. 특히 GA4 는
+// analytics.edit 스코프를 새로 추가했으므로 기존 사용자는 재로그인 안내가 필수.
+const ga4: typeof ga4Raw = new Proxy(ga4Raw, {
+  get(target, prop, receiver) {
+    const orig = Reflect.get(target, prop, receiver);
+    if (typeof orig !== 'function') return orig;
+    return (...args: unknown[]) => {
+      try {
+        const out = (orig as (...a: unknown[]) => unknown)(...args);
+        if (out && typeof (out as { then?: unknown }).then === 'function') {
+          return (out as Promise<unknown>).catch((err) => {
+            throw friendlyGoogleError(err);
+          });
+        }
+        return out;
+      } catch (err) {
+        throw friendlyGoogleError(err);
+      }
+    };
+  },
+});
+
+const PROPERTY_DESC = "GA4 property ID — '123456789' 또는 'properties/123456789'";
+
+export function registerGa4Tools(server: McpServer) {
+  server.tool(
+    'ga4_list_account_summaries',
+    '접근 가능한 Google Analytics 계정 + 각 계정의 GA4 property 요약. accountId / propertyId 를 확인할 때 먼저 호출. analytics.edit 스코프 필요(없으면 재로그인 안내).',
+    {},
+    async () => {
+      const auth = await requireAuth(ga4Raw.GA4_SCOPE);
+      const summaries = await ga4.listAccountSummaries(auth);
+      return { content: [{ type: 'text', text: JSON.stringify(summaries, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'ga4_list_properties',
+    '특정 GA 계정 하위 GA4 property 목록.',
+    { accountId: z.string().describe("GA 계정 ID — '123' 또는 'accounts/123'") },
+    async ({ accountId }) => {
+      const auth = await requireAuth(ga4Raw.GA4_SCOPE);
+      const properties = await ga4.listProperties(auth, accountId);
+      return { content: [{ type: 'text', text: JSON.stringify(properties, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'ga4_create_property',
+    '새 GA4 property 생성. 생성 후 ga4_create_data_stream 으로 플랫폼별 stream(웹=measurement ID, 앱=firebaseAppId)을 붙인다.',
+    {
+      accountId: z.string().describe("GA 계정 ID — '123' 또는 'accounts/123'"),
+      displayName: z.string().describe('property 표시 이름 (예: SpeakReward)'),
+      timeZone: z.string().optional().describe("IANA 타임존 (기본 'America/Los_Angeles', 예: 'Asia/Seoul')"),
+      currencyCode: z.string().optional().describe("ISO 4217 통화코드 (기본 'USD', 예: 'KRW')"),
+    },
+    async ({ accountId, displayName, timeZone, currencyCode }) => {
+      const auth = await requireAuth(ga4Raw.GA4_SCOPE);
+      const property = await ga4.createProperty(auth, { accountId, displayName, timeZone, currencyCode });
+      return { content: [{ type: 'text', text: JSON.stringify(property, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'ga4_create_data_stream',
+    'GA4 property 에 data stream 생성. web → measurementId(G-XXXX) 반환, android/ios → firebaseAppId 반환(Firebase 링크 시). RN 앱은 android/ios 스트림 사용.',
+    {
+      propertyId: z.string().describe(PROPERTY_DESC),
+      platform: z.enum(['web', 'android', 'ios']).describe('스트림 플랫폼'),
+      displayName: z.string().describe('스트림 표시 이름'),
+      defaultUri: z.string().optional().describe('web 전용 — 사이트 URL (예: https://example.com)'),
+      packageName: z.string().optional().describe('android 전용 — 패키지명 (예: com.example.app)'),
+      bundleId: z.string().optional().describe('ios 전용 — Bundle ID (예: com.example.app)'),
+    },
+    async ({ propertyId, platform, displayName, defaultUri, packageName, bundleId }) => {
+      const auth = await requireAuth(ga4Raw.GA4_SCOPE);
+      const stream = await ga4.createDataStream(auth, propertyId, {
+        platform,
+        displayName,
+        defaultUri,
+        packageName,
+        bundleId,
+      });
+      return { content: [{ type: 'text', text: JSON.stringify(stream, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'ga4_list_data_streams',
+    'GA4 property 의 data stream 목록 (measurementId / firebaseAppId 평탄화).',
+    { propertyId: z.string().describe(PROPERTY_DESC) },
+    async ({ propertyId }) => {
+      const auth = await requireAuth(ga4Raw.GA4_SCOPE);
+      const streams = await ga4.listDataStreams(auth, propertyId);
+      return { content: [{ type: 'text', text: JSON.stringify(streams, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'ga4_run_report',
+    'GA4 Data API 리포트 (활성 사용자·이벤트 등). dimensions/metrics 는 쉼표 구분 GA4 API 이름.',
+    {
+      propertyId: z.string().describe(PROPERTY_DESC),
+      startDate: z.string().describe("시작일 (YYYY-MM-DD 또는 'NdaysAgo', 'today')"),
+      endDate: z.string().describe("종료일 (YYYY-MM-DD 또는 'today')"),
+      dimensions: z.string().optional().describe('쉼표 구분 dimension (예: date,country). 생략 시 전체 합계'),
+      metrics: z.string().optional().describe('쉼표 구분 metric (기본 activeUsers,eventCount)'),
+    },
+    async ({ propertyId, startDate, endDate, dimensions, metrics }) => {
+      const auth = await requireAuth(ga4Raw.GA4_SCOPE);
+      const report = await ga4.runReport(auth, propertyId, {
+        startDate,
+        endDate,
+        dimensions: dimensions ? dimensions.split(',').map((d) => d.trim()).filter(Boolean) : undefined,
+        metrics: metrics ? metrics.split(',').map((m) => m.trim()).filter(Boolean) : undefined,
+      });
+      return { content: [{ type: 'text', text: JSON.stringify(report, null, 2) }] };
+    },
+  );
+}


### PR DESCRIPTION
## 무엇

앱(예: Expo `speakreward`)에 **Firebase · AdMob · GA4**를 mimi-seed-sdk로 붙일 수 있게 한다. SDK 책임 경계는 **클라우드 프로비저닝 + config 산출**까지 — 앱 레포 와이어링(deps/plugin/파일 배치/prebuild)은 범위 밖.

## 변경

### GA4 (신규)
- `ga4/tools.ts` + `registers/ga4.ts`: `ga4_list_account_summaries` / `list_properties` / `create_property` / `create_data_stream`(web→`measurementId`, app→`firebaseAppId`) / `list_data_streams` / `run_report`. Analytics Admin(v1beta) + Data(v1beta).
- `analytics.edit` 스코프 추가. **⚠️ 기존 mimi-seed 사용자 전원 1회 재로그인 필요** (모든 프로젝트 공통). 토큰에 `scope` 영속화 + `requireAuth(scope)` pre-flight 검사로 런타임 `ACCESS_TOKEN_SCOPE_INSUFFICIENT` 대신 결정적 재로그인 안내.

### Firebase (보강)
- `firebase_link_analytics`(addGoogleAnalytics) / `firebase_get_analytics_details`. `analyticsAccountId`(신규 property) 또는 `analyticsPropertyId`(기존) 중 하나 필수 — 빈 body 가드.
- `COMMON_SERVICES`에 `firebaseanalytics.googleapis.com` 추가.

### AdMob (보강)
- `createApp`: `appStoreId`로 스토어 링크(Android=패키지명, iOS=숫자ID). `displayName`은 writable한 `manualAppInfo`로 라우팅(`linkedAppInfo.displayName`은 output-only).
- `adTypes`를 `adFormat`에서 파생(`RICH_MEDIA`/`VIDEO`만 유효, `REWARDED_INTERSTITIAL`=video-only).
- **⚠️ `create-*`는 v1beta Limited Access** — 계정 allowlist 없으면 403(콘솔 수동 폴백 유지).

### CLI (도메인별 bin shell-out)
- `mimi-seed firebase|admob|ga4 <subcommand>` — cli 패키지가 `npx`로 mcp-server bin 호출(auth `runMcpBin` 선례). 신규 bin: `mimi-seed-firebase` / `-admob` / `-ga4`. 공유 `lib/cli-args.ts`.

## 검증
- 신규 npm 의존성 없음(`googleapis`가 `analyticsadmin`/`analyticsdata` 번들).
- 빌드 클린, 테스트 **156개 통과**.
- 적대적 리뷰(17 에이전트)로 발견한 **6건 수정 반영**: adTypes enum(critical), linkAnalytics 빈 body, scope pre-flight, manualAppInfo 라우팅, parseArgs `--key=value`, firebase `--platform` 정규화.

## 사용 예 (speakreward iOS)
```
mimi-seed firebase create-ios --project <pid> --bundle gg.pryzm.speakreward --name SpeakReward
mimi-seed firebase config --project <pid> --app <appId> --platform ios   # GoogleService-Info.plist
mimi-seed ga4 create-property --account <gaAccount> --name SpeakReward --timezone Asia/Seoul --currency KRW
mimi-seed ga4 create-stream --property <pid> --platform ios --name "SpeakReward iOS" --bundle gg.pryzm.speakreward
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)