### PR TITLE
feat: project-manifest-aware status/doctor + BigQuery status fix

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Mimi Seed CLI — Claude Code와 Codex에서 앱 출시 운영을 관리합니다.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -6,6 +6,12 @@ import { getEffectiveConfig } from "./config.js";
 import { mcpCall } from "./mcp-client.js";
 import { isGitRepo, getLatestTag, getGitLog } from "./git.js";
 import { detectHints } from "./detect.js";
+import {
+  findProjectManifest,
+  manifestServiceEntries,
+  type ManifestServiceId,
+  type ManifestService,
+} from "./project-manifest.js";
 
 function ok(label: string, detail = "") {
   process.stdout.write(`  ${kleur.green("✓")} ${label}${detail ? kleur.dim("  " + detail) : ""}\n`);
@@ -18,6 +24,22 @@ function fail(label: string, detail = "") {
 }
 function section(title: string) {
   process.stdout.write("\n" + kleur.dim(`── ${title} ──\n`));
+}
+
+/** 매니페스트 서비스별 식별자 한 줄 (예: "ads-coffee / analytics_530080532"). */
+function manifestDetail(id: ManifestServiceId, svc: ManifestService): string {
+  const parts: string[] = [];
+  if (id === "bigquery") {
+    if (svc.projectId) parts.push(svc.projectId);
+    if (svc.dataset) parts.push(svc.dataset);
+  } else if (id === "playstore" && svc.packageName) {
+    parts.push(svc.packageName);
+  } else if (id === "appstore" && svc.keyId) {
+    parts.push(`keyId ${svc.keyId}`);
+  } else if (id === "jenkins" && svc.url) {
+    parts.push(svc.url);
+  }
+  return parts.join(" / ");
 }
 
 export async function cmdDoctor(): Promise<void> {
@@ -62,17 +84,52 @@ export async function cmdDoctor(): Promise<void> {
         return false;
       }
     })();
+  const oauthPresent = hasFile("tokens.json");
+  const appstorePresent = hasFile("appstore.json");
+  const bigquerySaPresent = hasPrefix("bigquery");
   const creds: Array<[string, boolean, string]> = [
-    ["Google OAuth (Firebase/AdMob/Play/Ads)", hasFile("tokens.json"), "mimi-seed auth login"],
-    ["App Store Connect", hasFile("appstore.json"), "mimi-seed auth appstore"],
+    ["Google OAuth (Firebase/AdMob/Play/Ads)", oauthPresent, "mimi-seed auth login"],
+    ["App Store Connect", appstorePresent, "mimi-seed auth appstore"],
     ["Play 서비스 계정 (선택 — OAuth로도 가능)", hasPlaySa, "mimi-seed auth playstore"],
-    ["BigQuery 서비스 계정", hasPrefix("bigquery"), "mimi-seed auth bigquery"],
+    ["BigQuery 서비스 계정", bigquerySaPresent, "mimi-seed auth bigquery"],
   ];
   for (const [label, present, cmd] of creds) {
     if (present) ok(label);
     else warn(label, `→ ${cmd}`);
   }
   process.stdout.write(kleur.dim("  OAuth 토큰 신선도 확인: mimi-seed auth status\n"));
+
+  // ── 프로젝트 매니페스트(.mimi-seed.json) 기반 요구사항 ──
+  // 저장소가 필요로 하는 서비스를 선언해두면, 로컬 자격증명 보유 여부와 대조해
+  // "이 프로젝트에서 너한테 빠진 것"을 정확히 짚어준다.
+  const loaded = findProjectManifest(cwd);
+  if (loaded) {
+    const projName = loaded.manifest.displayName ?? loaded.manifest.project ?? "이 프로젝트";
+    section(`${projName} 요구사항 (.mimi-seed.json)`);
+    // OAuth 는 BigQuery/Play 의 fallback 이기도 하므로 연결 판정에 함께 반영.
+    const connectedOf: Record<ManifestServiceId, boolean> = {
+      oauth: oauthPresent,
+      bigquery: bigquerySaPresent || oauthPresent,
+      playstore: hasPlaySa || oauthPresent,
+      appstore: appstorePresent,
+      jenkins: false, // mimi-seed 로컬 자격증명 대상 아님(별도 MCP) — note 로만 안내
+    };
+    const fixOf: Record<ManifestServiceId, string> = {
+      oauth: "mimi-seed auth login",
+      bigquery: "mimi-seed auth bigquery",
+      playstore: "mimi-seed auth playstore",
+      appstore: "mimi-seed auth appstore",
+      jenkins: "claude mcp add virgm-jenkins -s user",
+    };
+    for (const [id, svc] of manifestServiceEntries(loaded.manifest)) {
+      const required = svc.required !== false;
+      const connected = connectedOf[id];
+      const detail = manifestDetail(id, svc);
+      if (connected) ok(id, detail);
+      else if (!required) warn(`${id} (선택)`, svc.note ?? detail);
+      else fail(id, `→ ${fixOf[id]}${detail ? "  " + detail : ""}`);
+    }
+  }
 
   section("로컬 환경");
   const nodeVer = process.version;

--- a/packages/cli/src/project-manifest.ts
+++ b/packages/cli/src/project-manifest.ts
@@ -1,0 +1,72 @@
+// 프로젝트 매니페스트(.mimi-seed.json) 리더 — CLI 판.
+// mcp-server 패키지의 동명 리더와 스키마를 공유하지만, cli 는 mcp-server 를 의존하지 않으므로
+// (별도 npm 패키지) 최소 리더를 여기 둔다. 스키마 변경 시 양쪽을 함께 수정할 것.
+
+import fs from "node:fs";
+import path from "node:path";
+
+export const MANIFEST_FILENAME = ".mimi-seed.json";
+
+export type ManifestServiceId =
+  | "oauth"
+  | "bigquery"
+  | "playstore"
+  | "appstore"
+  | "jenkins";
+
+export interface ManifestService {
+  required?: boolean;
+  note?: string;
+  projectId?: string;
+  dataset?: string;
+  packageName?: string;
+  keyId?: string;
+  issuerId?: string;
+  url?: string;
+  workspaceProvider?: string;
+}
+
+export interface ProjectManifest {
+  project?: string;
+  displayName?: string;
+  description?: string;
+  services?: Partial<Record<ManifestServiceId, ManifestService>>;
+}
+
+export interface LoadedManifest {
+  manifest: ProjectManifest;
+  filePath: string;
+}
+
+/** startDir 에서 위로 올라가며 첫 `.mimi-seed.json` 을 찾는다. */
+export function findProjectManifest(
+  startDir: string = process.cwd(),
+  maxDepth = 8,
+): LoadedManifest | null {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i <= maxDepth; i++) {
+    const candidate = path.join(dir, MANIFEST_FILENAME);
+    if (fs.existsSync(candidate)) {
+      try {
+        const obj = JSON.parse(fs.readFileSync(candidate, "utf-8")) as ProjectManifest;
+        if (obj && typeof obj === "object") return { manifest: obj, filePath: candidate };
+      } catch {
+        /* 형식 오류 — null */
+      }
+      return null;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+export function manifestServiceEntries(
+  m: ProjectManifest,
+): Array<[ManifestServiceId, ManifestService]> {
+  const svc = m.services ?? {};
+  return (Object.keys(svc) as ManifestServiceId[])
+    .filter((k) => svc[k] != null)
+    .map((k) => [k, svc[k] as ManifestService]);
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Mimi Seed MCP server — Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/lib/project-manifest.ts
+++ b/packages/mcp-server/src/lib/project-manifest.ts
@@ -1,0 +1,95 @@
+// 프로젝트 매니페스트(.mimi-seed.json) 리더.
+//
+// 프로젝트 루트에 커밋된 `.mimi-seed.json` 이 "이 저장소를 mimi-seed 로 다루려면
+// 어떤 서비스 연결이 필요한가"를 선언한다. mimi_seed_status(MCP)와 mimi-seed doctor(CLI)가
+// 이 파일을 읽어, 범용 9종 스캔 대신 "이 프로젝트에서 너한테 빠진 것 + 정확한 셋업 명령"을 보여준다.
+//
+// 팀 온보딩 목적: 새 팀원이 clone → mimi_seed_status 호출 → 안내 따라가기 만으로
+// 자기 머신에 필요한 자격증명을 채울 수 있게 한다.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const MANIFEST_FILENAME = '.mimi-seed.json';
+
+/** 매니페스트가 인지하는 서비스 id. status 매칭 로직이 이 키를 기준으로 동작한다. */
+export type ManifestServiceId =
+  | 'oauth'
+  | 'bigquery'
+  | 'playstore'
+  | 'appstore'
+  | 'jenkins';
+
+export interface ManifestService {
+  /** 이 프로젝트에서 필수인지. false(선택)면 미설정이어도 ❌ 대신 정보 표기. */
+  required?: boolean;
+  /** 사람이 읽을 한 줄 설명. status 출력에 그대로 표시. */
+  note?: string;
+  // 서비스별 식별자 — status 힌트에 그대로 끼워 넣어 "정확한 명령"을 만든다.
+  projectId?: string;   // bigquery GCP project
+  dataset?: string;     // bigquery dataset
+  packageName?: string; // playstore package
+  keyId?: string;       // appstore ASC key id
+  issuerId?: string;    // appstore issuer id
+  url?: string;         // jenkins url
+  /** 이 서비스가 워크스페이스 공유 시크릿(provider)으로도 제공되는 경우 그 provider id. */
+  workspaceProvider?: string;
+}
+
+export interface ProjectManifest {
+  project?: string;
+  displayName?: string;
+  description?: string;
+  services?: Partial<Record<ManifestServiceId, ManifestService>>;
+}
+
+export interface LoadedManifest {
+  manifest: ProjectManifest;
+  /** 실제로 읽은 파일 절대 경로. */
+  filePath: string;
+}
+
+/**
+ * startDir 에서 위로 올라가며 첫 번째 `.mimi-seed.json` 을 찾는다.
+ * MCP stdio 서버의 cwd 는 보통 프로젝트 루트지만, 하위 폴더에서 실행돼도 잡히게 상향 탐색한다.
+ * maxDepth 로 홈 디렉터리 밖까지 무한 상승하는 것을 방지.
+ */
+export function findProjectManifest(
+  startDir: string = process.cwd(),
+  maxDepth = 8,
+): LoadedManifest | null {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i <= maxDepth; i++) {
+    const candidate = path.join(dir, MANIFEST_FILENAME);
+    if (fs.existsSync(candidate)) {
+      const parsed = safeParse(candidate);
+      if (parsed) return { manifest: parsed, filePath: candidate };
+      return null; // 파일은 있으나 형식 오류 — 상위로 더 올라가지 않는다(의도 명확).
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // 루트 도달
+    dir = parent;
+  }
+  return null;
+}
+
+function safeParse(filePath: string): ProjectManifest | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const obj = JSON.parse(raw) as ProjectManifest;
+    if (obj && typeof obj === 'object') return obj;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** 매니페스트 services 를 [id, service] 배열로. 없으면 빈 배열. */
+export function manifestServiceEntries(
+  m: ProjectManifest,
+): Array<[ManifestServiceId, ManifestService]> {
+  const svc = m.services ?? {};
+  return (Object.keys(svc) as ManifestServiceId[])
+    .filter((k) => svc[k] != null)
+    .map((k) => [k, svc[k] as ManifestService]);
+}

--- a/packages/mcp-server/src/registers/auth.ts
+++ b/packages/mcp-server/src/registers/auth.ts
@@ -8,7 +8,13 @@ import { loadCiConfig } from '../ci/config.js';
 import { loadConfig as loadGoogleAdsConfig } from '../googleads/config.js';
 import { loadFacebookConfig } from '../facebook/config.js';
 import { loadInstagramConfig } from '../instagram/config.js';
-import { getBigQueryServiceAccountKey } from '../auth/bigquery-auth.js';
+import { resolveBigQueryAuth } from '../auth/bigquery-auth.js';
+import {
+  findProjectManifest,
+  manifestServiceEntries,
+  type ManifestServiceId,
+  type ManifestService,
+} from '../lib/project-manifest.js';
 
 /**
  * tokens.json mtime → "Nd Hh ago" 형식 문자열 + 재인증 권고.
@@ -34,6 +40,55 @@ function formatLastRefreshHint(lastMs: number | null): { label: string; recommen
     };
   }
   return { label };
+}
+
+// 매니페스트 서비스별 셋업 명령. status/doctor 가 "정확한 다음 명령"으로 안내한다.
+const MANIFEST_FIX: Record<ManifestServiceId, (svc: ManifestService) => string> = {
+  oauth: () => 'mimi_seed_auth_start  (Google 로그인 — Firebase/AdMob/Play/GSC/GA4)',
+  bigquery: () => 'npx -y @yoonion/mimi-seed-mcp mimi-seed-bigquery-auth  (서비스 계정 권장)',
+  playstore: (svc) =>
+    svc.packageName
+      ? `setup_playstore_connection(packageName="${svc.packageName}")`
+      : 'setup_playstore_connection(packageName=...)',
+  appstore: () => 'npx -y @yoonion/mimi-seed-mcp mimi-seed-appstore-auth',
+  jenkins: () => 'claude mcp add virgm-jenkins -s user  (개인 자격증명 — .mcp.json 금지)',
+};
+
+/** 서비스별 식별자를 한 줄 detail 로 (예: "ads-coffee / analytics_530080532"). */
+function manifestServiceDetail(id: ManifestServiceId, svc: ManifestService): string {
+  const parts: string[] = [];
+  if (id === 'bigquery') {
+    if (svc.projectId) parts.push(svc.projectId);
+    if (svc.dataset) parts.push(svc.dataset);
+  } else if (id === 'playstore') {
+    if (svc.packageName) parts.push(svc.packageName);
+  } else if (id === 'appstore') {
+    if (svc.keyId) parts.push(`keyId ${svc.keyId}`);
+  } else if (id === 'jenkins') {
+    if (svc.url) parts.push(svc.url);
+  }
+  return parts.join(' / ');
+}
+
+/** 매니페스트 한 서비스를 status 라인(들)으로 렌더. 미설정+필수면 명령 힌트를 붙인다. */
+function renderManifestLine(
+  id: ManifestServiceId,
+  svc: ManifestService,
+  connected: boolean,
+  required: boolean,
+): string {
+  const label = id.padEnd(10);
+  const detail = manifestServiceDetail(id, svc);
+  const detailSuffix = detail ? ` (${detail})` : '';
+
+  if (connected) return `✅ ${label} — 연결됨${detailSuffix}`;
+  if (!required) {
+    const note = svc.note ? ` — ${svc.note}` : '';
+    return `ℹ️  ${label} — (선택)${detailSuffix}${note}`;
+  }
+  const fix = MANIFEST_FIX[id](svc);
+  const noteLine = svc.note ? `\n     ${svc.note}` : '';
+  return `❌ ${label} — 미설정${detailSuffix}\n     → ${fix}${noteLine}`;
 }
 
 export function registerAuthTools(server: McpServer) {
@@ -120,10 +175,13 @@ export function registerAuthTools(server: McpServer) {
         lines.push('❌ Instagram         — 미설정 → instagram_save_config  (선택)');
       }
 
-      // 9. BigQuery
-      const bq = getBigQueryServiceAccountKey();
-      if (bq) {
-        lines.push(`✅ BigQuery          — 서비스 계정 연결됨 (${(bq as { client_email?: string }).client_email ?? ''})`);
+      // 9. BigQuery — resolveBigQueryAuth 기준(서비스 계정 우선, OAuth fallback).
+      // 이전엔 SA 파일만 검사해 OAuth fallback 이 살아있어도 ❌ 로 오표기했다.
+      const bqAuth = resolveBigQueryAuth();
+      if (bqAuth?.source === 'service-account') {
+        lines.push(`✅ BigQuery          — 서비스 계정 연결됨 (${bqAuth.clientEmail ?? ''})`);
+      } else if (bqAuth?.source === 'user-oauth') {
+        lines.push('⚠️  BigQuery          — OAuth fallback (Workspace 재인증 정책 시 끊길 수 있음 → 서비스 계정 권장: mimi-seed-bigquery-auth)');
       } else {
         lines.push('❌ BigQuery          — 미설정 → npx @yoonion/mimi-seed-mcp mimi-seed-bigquery-auth  (선택)');
       }
@@ -144,6 +202,46 @@ export function registerAuthTools(server: McpServer) {
         lines.push('', '── 다음 단계 (필수) ─────────────────────────────', ...missing);
       } else {
         lines.push('', '✅ 필수 연결 모두 완료. 앱 출시 작업을 시작할 수 있습니다.');
+      }
+
+      // ── 프로젝트 매니페스트(.mimi-seed.json) 기반 요구사항 ────────────────────
+      // 이 저장소가 "무엇을 필요로 하는가"를 선언해두면, 범용 스캔 대신
+      // "이 프로젝트에서 너한테 빠진 것 + 정확한 셋업 명령"을 팀원별로 보여준다.
+      const loaded = findProjectManifest();
+      if (loaded) {
+        const oauthOk = oauthResult.status === 'fresh' || oauthResult.status === 'refreshed';
+        const playstoreCovers = (pkg?: string) =>
+          saCount > 0 &&
+          (!pkg || !!saInfo.default || saInfo.perPackage.some((p) => p.packageName === pkg));
+
+        const state: Record<ManifestServiceId, boolean> = {
+          oauth: oauthOk,
+          bigquery: !!bqAuth,
+          playstore: playstoreCovers(),
+          appstore: !!asc,
+          jenkins: !!jenkins,
+        };
+
+        const projName = loaded.manifest.displayName ?? loaded.manifest.project ?? '이 프로젝트';
+        const reqLines: string[] = ['', `── ${projName} 요구사항 (.mimi-seed.json) ─────────`];
+        let anyMissing = false;
+
+        for (const [id, svc] of manifestServiceEntries(loaded.manifest)) {
+          const required = svc.required !== false;
+          const connected =
+            id === 'playstore' ? playstoreCovers(svc.packageName) : state[id];
+          reqLines.push(renderManifestLine(id, svc, connected, required));
+          if (required && !connected) anyMissing = true;
+        }
+
+        if (anyMissing) {
+          reqLines.push(
+            '',
+            'ℹ️  팀 공유가 목표라면, 각자 로컬 자격증명을 채우는 대신',
+            '   워크스페이스(https://mimi-seed.pryzm.gg) 초대 → PAT 발급 → 원격 MCP 연결도 가능.',
+          );
+        }
+        lines.push(...reqLines);
       }
 
       return { content: [{ type: 'text', text: lines.join('\n') }] };


### PR DESCRIPTION
## What

`mimi_seed_status` (MCP) and `mimi-seed doctor` (CLI) now read a project's `.mimi-seed.json` manifest and report, **per teammate**, which required services are missing plus the exact setup command — instead of a generic 9-service scan. This is the onboarding piece so a teammate who clones a repo learns exactly what to connect (e.g. "BigQuery not connected → mimi-seed auth bigquery").

## Changes

- New `project-manifest.ts` reader in both packages (mcp-server + cli). Duplicated intentionally — they're separate npm packages with no shared dep.
- `mimi_seed_status`: fixed the BigQuery line to use `resolveBigQueryAuth()` so the **OAuth fallback is reported honestly** (previously only checked the SA file → false ❌ even when OAuth was live).
- Manifest-aware section in both status and doctor: maps each required service to ✅/❌/ℹ️ with the precise fix command and the project's identifiers baked in.
- Version bump: `@yoonion/mimi-seed-mcp` 0.4.0→**0.5.0**, `mimi-seed` (cli) 0.3.0→**0.4.0** — **already published to npm**.

## Verification

- `tsc` clean on both packages; vitest: mcp-server 156 + cli 39 pass.
- Smoke-tested `mimi-seed doctor` from a project dir — renders the "requirements" section correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)