### PR TITLE
fix(codex): use supported remote MCP configuration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed",
   "displayName": "Mimi Seed",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Claude Code에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -40,6 +40,9 @@ mimi-seed init
 mimi-seed mcp codex --write
 ```
 
+원격 PAT는 `config.toml`에 평문으로 저장되지 않습니다. Codex를 실행하는 환경의 `MIMI_SEED_TOKEN`에 PAT를
+설정하고 Codex를 다시 시작하세요. 원격 항목 이름은 로컬 stdio 서버와 충돌하지 않는 `mimi-seed-remote`입니다.
+
 ## 프로젝트 측 설정
 
 프로젝트에서 `mimi-seed init`을 실행하면 Claude Code용 `.claude/mimi-seed.md`와 Codex용 `AGENTS.md`에 같은 운영 컨텍스트가 기록됩니다.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Codex에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/README.ko.md
+++ b/README.ko.md
@@ -71,6 +71,10 @@ claude mcp add --transport http mimi-seed https://mimi-seed.pryzm.gg/api/mcp \
 
 # 3-b. 또는 Codex에 등록:
 npx mimi-seed mcp codex --write
+# 설정 파일에는 PAT 대신 MIMI_SEED_TOKEN 환경변수 이름만 기록됩니다.
+# Codex를 실행하는 환경에 값을 넣고 Codex를 다시 시작하세요.
+export MIMI_SEED_TOKEN="<PAT>"        # bash/zsh
+# PowerShell: $env:MIMI_SEED_TOKEN="<PAT>"
 ```
 
 끝. Claude Code 또는 Codex에서 바로 사용할 수 있어요.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ claude mcp add --transport http mimi-seed https://mimi-seed.pryzm.gg/api/mcp \
 
 # 3-b. Or register in Codex:
 npx mimi-seed mcp codex --write
+# The config references MIMI_SEED_TOKEN instead of storing the PAT.
+# Set it in the environment that launches Codex, then restart Codex.
+export MIMI_SEED_TOKEN="<PAT>"        # bash/zsh
+# PowerShell: $env:MIMI_SEED_TOKEN="<PAT>"
 ```
 
 Done. Start talking to Claude Code or Codex.

--- a/docs/user-guide/team-security.ko.md
+++ b/docs/user-guide/team-security.ko.md
@@ -26,8 +26,10 @@ Mimi Seed는 팀 상태를 공유할 수 있지만 모든 자격증명을 공유
 
 ## Codex 설정 주의
 
-`mimi-seed mcp codex --write`는 사용자 홈의 `~/.codex/config.toml`에 Remote PAT를 평문으로 저장할 수 있다.
-파일 권한을 제한하고 저장소의 `.codex/config.toml`로 복사하지 않는다. 프로젝트 설정에 토큰이 들어 있다면 커밋하지 않는다.
+`mimi-seed mcp codex --write`는 `[mcp_servers.mimi-seed-remote]` HTTP 항목을 별도로 만들고 PAT 대신
+`bearer_token_env_var = "MIMI_SEED_TOKEN"`만 기록한다. Codex를 실행하는 프로세스에 이 환경변수를 설정하고
+Codex를 다시 시작한 뒤 `codex mcp list`로 확인한다. 저장소 `.codex/config.toml`에는 PAT를 넣지 말고, 과거
+인라인 `http_headers` 토큰을 커밋하거나 복사한 적이 있다면 제거한다.
 
 ## CI 자동화 게이트
 

--- a/docs/user-guide/team-security.md
+++ b/docs/user-guide/team-security.md
@@ -26,9 +26,10 @@ allows, and never put secrets in them.
 
 ## Codex configuration warning
 
-`mimi-seed mcp codex --write` can store a Remote PAT in plaintext in the user's `~/.codex/config.toml`. Restrict
-file permissions and do not copy it into a repository `.codex/config.toml`. Never commit project configuration
-that contains a token.
+`mimi-seed mcp codex --write` writes a separate `[mcp_servers.mimi-seed-remote]` HTTP entry. It stores
+`bearer_token_env_var = "MIMI_SEED_TOKEN"`, not the PAT itself. Set that environment variable in the process that
+launches Codex, restart Codex, and verify with `codex mcp list`. Never put the PAT in a repository
+`.codex/config.toml`; remove any legacy inline `http_headers` token if one was committed or copied elsewhere.
 
 ## CI automation gates
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed-sdk",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Monorepo root — the SDK version (SSOT for both packages and client plugin manifests) plus bootstrap scripts. The publishable packages live in packages/. This is NOT an npm workspace: each package installs independently.",
   "type": "module",
   "engines": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -310,6 +310,9 @@ Codex는 자동 쓰기 명령을 사용할 수 있습니다.
 mimi-seed mcp codex --write
 ```
 
+이 명령은 `mimi-seed-remote` HTTP 항목과 `bearer_token_env_var = "MIMI_SEED_TOKEN"`을 기록하며 PAT 자체는
+`config.toml`에 쓰지 않습니다. Codex를 실행하는 환경에 `MIMI_SEED_TOKEN`을 설정하고 Codex를 다시 시작하세요.
+
 등록 후 Claude Code 또는 Codex에서 대화로 제어:
 
 ```

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Mimi Seed CLI — Claude Code와 Codex에서 앱 출시 운영을 관리합니다.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/cli/src/__tests__/mcp-config.test.ts
+++ b/packages/cli/src/__tests__/mcp-config.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { claudeMcpAddCommand } from "../mcp-config.js";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { claudeMcpAddCommand, writeCodexMcpConfig } from "../mcp-config.js";
 import type { MimiSeedConfig } from "../config.js";
 
 const cfg: MimiSeedConfig = {
@@ -22,5 +25,69 @@ describe("claudeMcpAddCommand", () => {
     expect(cmd).toContain(`Bearer ${cfg.token}`);
     expect(cmd).not.toContain("...");
     expect(cmd).toContain(cfg.endpoint);
+  });
+});
+
+describe("writeCodexMcpConfig", () => {
+  let home: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "mimi-codex-"));
+    vi.spyOn(os, "homedir").mockReturnValue(home);
+    configPath = path.join(home, ".codex", "config.toml");
+  });
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  // Codex 0.132 는 인라인 http_headers 를 파싱 못 해 url 항목을 stdio 로 오인하고
+  // "url is not supported for stdio" 로 config 전체를 거부했다. 반드시 이 형식이어야 한다.
+  it("Codex 가 받는 형식으로 쓴다 — url + bearer_token_env_var, http_headers 없음", async () => {
+    await writeCodexMcpConfig(cfg);
+    const out = fs.readFileSync(configPath, "utf8");
+    expect(out).toContain("[mcp_servers.mimi-seed-remote]");
+    expect(out).toContain(`url = "${cfg.endpoint}"`);
+    expect(out).toContain('bearer_token_env_var = "MIMI_SEED_TOKEN"');
+    expect(out).not.toContain("http_headers");
+    // 토큰을 config 에 평문으로 남기지 않는다 (env var 로 읽는다).
+    expect(out).not.toContain(cfg.token);
+  });
+
+  // 플러그인이 등록한 로컬 stdio `mimi-seed` (command/args) 와 충돌하지 않도록 이름을 분리한다.
+  it("stdio `mimi-seed` 옆에 추가해도 그 항목을 건드리지 않는다", async () => {
+    const stdio = '[mcp_servers.mimi-seed]\ncommand = "npx"\nargs = ["-y", "@yoonion/mimi-seed-mcp"]\n';
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, stdio);
+
+    await writeCodexMcpConfig(cfg);
+    const out = fs.readFileSync(configPath, "utf8");
+    expect(out).toContain('command = "npx"'); // stdio 보존
+    expect(out).toContain("[mcp_servers.mimi-seed-remote]"); // 원격은 별도 이름
+  });
+
+  // 과거 버전이 쓴 깨진 원격 블록(url 이 mimi-seed 이름에 들어간)을 청소한다.
+  it("레거시 [mcp_servers.mimi-seed] url 블록을 제거한다", async () => {
+    const legacy =
+      '[mcp_servers.mimi-seed]\nurl = "https://old/api/mcp"\nenabled = true\n' +
+      "[mcp_servers.mimi-seed.http_headers]\nAuthorization = \"Bearer old\"\n";
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, legacy);
+
+    await writeCodexMcpConfig(cfg);
+    const out = fs.readFileSync(configPath, "utf8");
+    expect(out).not.toContain("[mcp_servers.mimi-seed.http_headers]");
+    expect(out).not.toContain("https://old/api/mcp");
+    expect(out).not.toMatch(/\[mcp_servers\.mimi-seed\]/); // 정확히 그 이름(대괄호 닫힘)만
+    expect(out).toContain("[mcp_servers.mimi-seed-remote]");
+  });
+
+  // 재실행해도 원격 블록이 하나만 유지된다 (멱등).
+  it("멱등 — 두 번 써도 mimi-seed-remote 블록이 하나", async () => {
+    await writeCodexMcpConfig(cfg);
+    await writeCodexMcpConfig(cfg);
+    const out = fs.readFileSync(configPath, "utf8");
+    expect(out.match(/\[mcp_servers\.mimi-seed-remote\]/g)?.length).toBe(1);
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -79,12 +79,12 @@ const M = catalog(
     logoutDone: "✓ 로컬 설정 삭제 완료.",
     logoutRevoke: "웹에서 토큰 해지: /workspace/api-tokens",
 
-    codexWritten: "✓ Codex MCP 설정 완료",
-    codexWriteWarn: "  ⚠ config.toml에 실제 토큰이 평문으로 저장됩니다 (파일 권한 확인 권장).",
+    codexWritten: "✓ Codex MCP 설정 완료 (mimi-seed-remote, HTTP)",
+    codexWriteWarn: "  ⚠ 토큰은 config 에 평문 저장하지 않습니다 — MIMI_SEED_TOKEN 환경변수에 PAT 를 넣어야 인증됩니다.",
     codexVerify: "Codex를 새로 열고 `/mcp` 또는 `codex mcp list`로 확인하세요.",
     codexTitle: "Codex MCP 등록",
     codexAuto: "자동 등록:",
-    codexManual: "수동 등록 예시 (~/.codex/config.toml) — 실제 토큰 포함:",
+    codexManual: "수동 등록 예시 (~/.codex/config.toml) — 토큰은 MIMI_SEED_TOKEN 환경변수로:",
     claudeTitle: "Claude Code MCP 등록 — 아래 한 줄을 그대로 실행하세요:",
     claudeWarn:
       "  ⚠ 실제 토큰이 포함된 명령입니다 (셸 히스토리에 남음). 토큰은 ~/.mimi-seed/config.json 에도 저장되어 있습니다.",
@@ -253,13 +253,13 @@ ${kleur.bold("환경변수:")}
     logoutDone: "✓ Local config deleted.",
     logoutRevoke: "Revoke the token on the web: /workspace/api-tokens",
 
-    codexWritten: "✓ Codex MCP configured",
+    codexWritten: "✓ Codex MCP configured (mimi-seed-remote, HTTP)",
     codexWriteWarn:
-      "  ⚠ The real token is stored in plain text in config.toml (check the file permissions).",
+      "  ⚠ The token is NOT written to the config — set MIMI_SEED_TOKEN to your PAT so the remote authenticates.",
     codexVerify: "Reopen Codex and verify with `/mcp` or `codex mcp list`.",
     codexTitle: "Codex MCP registration",
     codexAuto: "Automatic:",
-    codexManual: "Manual example (~/.codex/config.toml) — contains the real token:",
+    codexManual: "Manual example (~/.codex/config.toml) — token via the MIMI_SEED_TOKEN env var:",
     claudeTitle: "Claude Code MCP registration — run this one line as-is:",
     claudeWarn:
       "  ⚠ This command contains the real token (it stays in your shell history). The token is also stored in ~/.mimi-seed/config.json.",
@@ -612,10 +612,10 @@ async function cmdMcp(args: string[]): Promise<void> {
     log(kleur.cyan("  mimi-seed mcp codex --write"));
     log("");
     log(M().codexManual);
-    log(`[mcp_servers.mimi-seed]
+    log(`[mcp_servers.mimi-seed-remote]
 url = "${cfg.endpoint}"
-enabled = true
-http_headers = { Authorization = "Bearer ${cfg.token}" }`);
+bearer_token_env_var = "MIMI_SEED_TOKEN"
+enabled = true`);
     return;
   }
 

--- a/packages/cli/src/mcp-config.ts
+++ b/packages/cli/src/mcp-config.ts
@@ -5,7 +5,17 @@ import kleur from "kleur";
 import type { MimiSeedConfig } from "./config.js";
 import { catalog } from "./i18n.js";
 
+// Claude Code 원격 HTTP 서버 이름.
 const SERVER_NAME = "mimi-seed";
+
+// Codex 원격 HTTP 서버는 **다른 이름**을 쓴다. Codex 플러그인/마켓플레이스가 로컬 stdio 서버를
+// `mimi-seed` 로 등록하는데, 같은 이름에 url 을 얹으면 Codex 가 그 항목을 stdio 로 보고
+// "url is not supported for stdio" 로 config 로드를 통째로 거부한다. 이름을 분리해 충돌을 없앤다.
+const CODEX_REMOTE_NAME = "mimi-seed-remote";
+
+// Codex 는 토큰을 인라인이 아니라 **환경변수 이름**으로 받는다 (`bearer_token_env_var`).
+// MIMI_SEED_TOKEN 은 CLI 가 이미 PAT 로 읽는 변수라 자연스럽게 맞물린다.
+const CODEX_TOKEN_ENV = "MIMI_SEED_TOKEN";
 
 // 안내 문구만 번역한다. 실제로 실행/기록되는 것(등록 명령, TOML 블록)은 언어와 무관하게 동일하다.
 const M = catalog(
@@ -14,15 +24,16 @@ const M = catalog(
     tokenWarning: (loc: string) =>
       `  ⚠ 실제 토큰이 포함된 명령입니다 (셸 히스토리에 남음). 토큰은 ${loc} 에도 저장되어 있습니다.`,
     codexTitle: "Codex MCP 등록:",
-    codexManual: "  # 또는 수동으로 ~/.codex/config.toml 에 [mcp_servers.mimi-seed] 추가",
+    codexEnvNote: `  # ${CODEX_TOKEN_ENV} 환경변수에 PAT 를 넣어야 원격 인증이 됩니다 (config 에 토큰을 평문 저장하지 않음).`,
+    codexManual: `  # 또는 수동으로:  codex mcp add ${CODEX_REMOTE_NAME} --url <endpoint> --bearer-token-env-var ${CODEX_TOKEN_ENV}`,
   },
   {
     claudeTitle: "Register the MCP server with Claude Code — run this single line as-is:",
     tokenWarning: (loc: string) =>
       `  ⚠ This command contains your real token (it lands in your shell history). The token is also stored in ${loc}.`,
     codexTitle: "Register with Codex:",
-    codexManual:
-      "  # or add [mcp_servers.mimi-seed] to ~/.codex/config.toml by hand",
+    codexEnvNote: `  # Set the ${CODEX_TOKEN_ENV} env var to your PAT so the remote authenticates (the token is not written to the config in plaintext).`,
+    codexManual: `  # or by hand:  codex mcp add ${CODEX_REMOTE_NAME} --url <endpoint> --bearer-token-env-var ${CODEX_TOKEN_ENV}`,
   },
 );
 
@@ -30,12 +41,14 @@ function tomlString(value: string): string {
   return JSON.stringify(value);
 }
 
+// Codex 0.132 형식: url + bearer_token_env_var. `http_headers` 인라인은 이 버전이 파싱하지 못해
+// stdio 로 오인 → "url is not supported for stdio" 로 config 전체가 안 뜬다.
 function codexBlock(cfg: MimiSeedConfig): string {
   return [
-    `[mcp_servers.${SERVER_NAME}]`,
+    `[mcp_servers.${CODEX_REMOTE_NAME}]`,
     `url = ${tomlString(cfg.endpoint)}`,
+    `bearer_token_env_var = ${tomlString(CODEX_TOKEN_ENV)}`,
     `enabled = true`,
-    `http_headers = { Authorization = ${tomlString(`Bearer ${cfg.token}`)} }`,
     "",
   ].join("\n");
 }
@@ -72,9 +85,20 @@ export function printMcpSetup(cfg: MimiSeedConfig): void {
       "",
       kleur.dim(M().codexTitle),
       kleur.dim("  mimi-seed mcp codex --write"),
+      kleur.dim(M().codexEnvNote),
       kleur.dim(M().codexManual),
     ].join("\n") + "\n",
   );
+}
+
+/** `[mcp_servers.name]` 테이블(있으면)을 통째로 제거. 잘못 쓰인 레거시 블록 청소용. */
+function removeTomlBlock(input: string, tableName: string): string {
+  const header = `[${tableName}]`;
+  const start = input.indexOf(header);
+  if (start < 0) return input;
+  const next = input.slice(start + header.length).search(/\n\[[^\]]+\]/);
+  const end = next < 0 ? input.length : start + header.length + next + 1;
+  return `${input.slice(0, start)}${input.slice(end).replace(/^\n+/, "\n")}`;
 }
 
 export async function writeCodexMcpConfig(cfg: MimiSeedConfig): Promise<string> {
@@ -89,7 +113,16 @@ export async function writeCodexMcpConfig(cfg: MimiSeedConfig): Promise<string> 
     current = "";
   }
 
-  const next = replaceTomlBlock(current, `mcp_servers.${SERVER_NAME}`, codexBlock(cfg));
+  // 과거 버전이 원격을 `[mcp_servers.mimi-seed]` (url + http_headers) 로 잘못 써서 Codex config
+  // 로드를 통째로 깨뜨렸다. 그 이름에 url 이 들어 있으면 레거시 잔재이므로 제거한다.
+  // (플러그인이 등록한 stdio `mimi-seed` — command/args — 는 건드리지 않는다.)
+  const legacy = current.match(/\[mcp_servers\.mimi-seed\]\s*\n(?:(?!\[)[\s\S])*/);
+  if (legacy && /^\s*url\s*=/m.test(legacy[0])) {
+    current = removeTomlBlock(current, "mcp_servers.mimi-seed");
+    current = removeTomlBlock(current, "mcp_servers.mimi-seed.http_headers");
+  }
+
+  const next = replaceTomlBlock(current, `mcp_servers.${CODEX_REMOTE_NAME}`, codexBlock(cfg));
   await fs.writeFile(configPath, next);
   return configPath;
 }

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Mimi Seed MCP server — Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/__tests__/docs-onboarding.test.ts
+++ b/packages/mcp-server/src/__tests__/docs-onboarding.test.ts
@@ -69,6 +69,14 @@ describe('온보딩 문서 ↔ 코드', () => {
     }
   });
 
+  it('Codex 원격 설정 문서가 PAT 평문 대신 환경변수 계약을 안내한다', () => {
+    for (const f of USER_GUIDE_PAIRS[9]) {
+      const doc = read(f);
+      expect(doc).toContain('mcp_servers.mimi-seed-remote');
+      expect(doc).toContain('bearer_token_env_var = "MIMI_SEED_TOKEN"');
+    }
+  });
+
   // ① 가장 ROI 높은 가드 — errors.ts 의 AuthErrorCode 유니온이 SSOT.
   it('모든 AuthErrorCode 가 troubleshooting 문서(EN·KO 양쪽)에 나온다', () => {
     const src = read('packages/mcp-server/src/auth/errors.ts');

--- a/plugins/mimi-seed/.codex-plugin/README.md
+++ b/plugins/mimi-seed/.codex-plugin/README.md
@@ -40,6 +40,9 @@ mimi-seed init
 mimi-seed mcp codex --write
 ```
 
+원격 PAT는 `config.toml`에 평문으로 저장되지 않습니다. Codex를 실행하는 환경의 `MIMI_SEED_TOKEN`에 PAT를
+설정하고 Codex를 다시 시작하세요. 원격 항목 이름은 로컬 stdio 서버와 충돌하지 않는 `mimi-seed-remote`입니다.
+
 ## 프로젝트 측 설정
 
 프로젝트에서 `mimi-seed init`을 실행하면 Claude Code용 `.claude/mimi-seed.md`와 Codex용 `AGENTS.md`에 같은 운영 컨텍스트가 기록됩니다.

--- a/plugins/mimi-seed/.codex-plugin/plugin.json
+++ b/plugins/mimi-seed/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Codex에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/plugins/mimi-seed/docs/user-guide/team-security.ko.md
+++ b/plugins/mimi-seed/docs/user-guide/team-security.ko.md
@@ -26,8 +26,10 @@ Mimi Seed는 팀 상태를 공유할 수 있지만 모든 자격증명을 공유
 
 ## Codex 설정 주의
 
-`mimi-seed mcp codex --write`는 사용자 홈의 `~/.codex/config.toml`에 Remote PAT를 평문으로 저장할 수 있다.
-파일 권한을 제한하고 저장소의 `.codex/config.toml`로 복사하지 않는다. 프로젝트 설정에 토큰이 들어 있다면 커밋하지 않는다.
+`mimi-seed mcp codex --write`는 `[mcp_servers.mimi-seed-remote]` HTTP 항목을 별도로 만들고 PAT 대신
+`bearer_token_env_var = "MIMI_SEED_TOKEN"`만 기록한다. Codex를 실행하는 프로세스에 이 환경변수를 설정하고
+Codex를 다시 시작한 뒤 `codex mcp list`로 확인한다. 저장소 `.codex/config.toml`에는 PAT를 넣지 말고, 과거
+인라인 `http_headers` 토큰을 커밋하거나 복사한 적이 있다면 제거한다.
 
 ## CI 자동화 게이트
 

--- a/plugins/mimi-seed/docs/user-guide/team-security.md
+++ b/plugins/mimi-seed/docs/user-guide/team-security.md
@@ -26,9 +26,10 @@ allows, and never put secrets in them.
 
 ## Codex configuration warning
 
-`mimi-seed mcp codex --write` can store a Remote PAT in plaintext in the user's `~/.codex/config.toml`. Restrict
-file permissions and do not copy it into a repository `.codex/config.toml`. Never commit project configuration
-that contains a token.
+`mimi-seed mcp codex --write` writes a separate `[mcp_servers.mimi-seed-remote]` HTTP entry. It stores
+`bearer_token_env_var = "MIMI_SEED_TOKEN"`, not the PAT itself. Set that environment variable in the process that
+launches Codex, restart Codex, and verify with `codex mcp list`. Never put the PAT in a repository
+`.codex/config.toml`; remove any legacy inline `http_headers` token if one was committed or copied elsewhere.
 
 ## CI automation gates
 


### PR DESCRIPTION
## Summary
- recover Claude's Codex 0.132 remote MCP configuration fix
- register the remote HTTP server as `mimi-seed-remote` so it does not collide with the plugin's local stdio server
- use `bearer_token_env_var = "MIMI_SEED_TOKEN"` instead of writing a PAT into `config.toml`
- remove legacy URL-based `[mcp_servers.mimi-seed]` blocks while preserving the local stdio entry
- update user documentation and add a documentation contract test
- release the patch as 0.10.2

## Validation
- CLI and MCP package builds
- `npm test` (MCP: 222 tests, CLI: 134 tests)
- focused onboarding documentation tests: 7 passed
- `npm run plugin:check`
- staged secret-pattern scan