### PR TITLE
refactor(mcp-server): tool-manifest.json as the single source for domain metadata

### DIFF
--- a/docs/domain/architecture.md
+++ b/docs/domain/architecture.md
@@ -119,8 +119,8 @@ Registered in `mcp-server/src/resources.ts` and `prompts.ts`:
 
 - **Resources** — `mimi-seed://auth/status` (Google OAuth freshness as JSON), `mimi-seed://agent/guide`
   (the full `docs/agent-guide.md`, served from the committed copy `packages/mcp-server/assets/agent-guide.md`
-  — refreshed by `npm run plugin:sync`), and `mimi-seed://tools/catalog` (runtime capability index derived
-  from `tool-manifest.json` + the `DOMAIN_SUMMARY` map in `resources.ts`).
+  — refreshed by `npm run plugin:sync`), and `mimi-seed://tools/catalog` (runtime capability index served
+  verbatim from `tool-manifest.json`, which carries per-domain `label`/`credential`/`summary` metadata).
 - **Prompts → slash commands** — `getting-started`, `deploy`, `health`, `review-inbox`, surfaced in MCP
   clients as `/mimi-seed:<name>`. More in [[skills-plugins]].
 

--- a/docs/domain/skills-plugins.md
+++ b/docs/domain/skills-plugins.md
@@ -56,7 +56,8 @@ Exposed by the MCP server (`prompts.ts` / `resources.ts`, see [[architecture]]):
   [`docs/agent-guide.md`](../agent-guide.md), served from the committed copy `packages/mcp-server/assets/agent-guide.md`
   — refreshed by `npm run plugin:sync`, drift-guarded by `prompts-resources.test.ts`), and
   `mimi-seed://tools/catalog` (runtime capability index: every tool by domain with the credential each domain
-  needs, derived from `tool-manifest.json` + the `DOMAIN_SUMMARY` map in `resources.ts`).
+  needs, served verbatim from `tool-manifest.json` — the manifest carries the per-domain
+  `label`/`credential`/`summary` metadata, integrity-checked by `tool-manifest.test.ts`).
 
 These are available in **any** MCP client, independent of the skills (which are a Claude Code / Codex packaging
 concept).

--- a/packages/mcp-server/src/__tests__/docs-drift.test.ts
+++ b/packages/mcp-server/src/__tests__/docs-drift.test.ts
@@ -1,14 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { readToolManifest } from '../lib/package-root.js';
 
 // tool-manifest.json 은 등록 도구의 SSOT 이고, docs/domain/tool-catalog.md 는
 // "정확한 개수를 적어도 되는" 유일한 산문 문서다 (docs/domain/_index.md 규칙).
 // tool-manifest.test.ts 가 manifest ↔ 서버를 강제하는 것과 짝을 이뤄,
 // 이 테스트는 manifest ↔ 카탈로그 문서를 강제한다 — 도구를 추가하고 문서를
 // 갱신하지 않으면 여기서 깨진다.
-const manifest = JSON.parse(
-  readFileSync(new URL('../../tool-manifest.json', import.meta.url), 'utf8'),
-) as { total: number; domains: Record<string, string[]> };
+const manifest = readToolManifest();
 
 const catalogUrl = new URL('../../../../docs/domain/tool-catalog.md', import.meta.url);
 const catalog = readFileSync(catalogUrl, 'utf8');
@@ -20,7 +19,7 @@ const REGISTER_FILE_BY_DOMAIN: Record<string, string> = Object.fromEntries(
 describe('docs/domain/tool-catalog.md ↔ tool-manifest.json', () => {
   it('모든 등록 도구가 카탈로그에 나열된다', () => {
     const missing = Object.values(manifest.domains)
-      .flat()
+      .flatMap((d) => d.tools)
       .filter((name) => !catalog.includes(`\`${name}\``));
     expect(
       missing,
@@ -43,11 +42,11 @@ describe('docs/domain/tool-catalog.md ↔ tool-manifest.json', () => {
     const documented = new Map(rows.map((r) => [r[1], Number(r[2])]));
 
     const mismatched: string[] = [];
-    for (const [domain, tools] of Object.entries(manifest.domains)) {
+    for (const [domain, entry] of Object.entries(manifest.domains)) {
       const file = REGISTER_FILE_BY_DOMAIN[domain];
       const shown = documented.get(file);
-      if (shown !== tools.length) {
-        mismatched.push(`${file}: 문서 ${shown ?? '없음'} ≠ 실제 ${tools.length}`);
+      if (shown !== entry.tools.length) {
+        mismatched.push(`${file}: 문서 ${shown ?? '없음'} ≠ 실제 ${entry.tools.length}`);
       }
     }
     expect(mismatched, `Counts by domain 표가 실제와 다릅니다 — ${mismatched.join(' · ')}`).toEqual(

--- a/packages/mcp-server/src/__tests__/helpers.ts
+++ b/packages/mcp-server/src/__tests__/helpers.ts
@@ -1,0 +1,21 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { buildServer } from '../server.js';
+
+/**
+ * 실제 서버를 InMemoryTransport 로 부팅해 client 를 넘겨주고, 끝나면 정리한다.
+ * 부트/해제 의식을 테스트마다 복사하지 말고 이 헬퍼를 쓸 것 — SDK 업그레이드로
+ * connect/close 프로토콜이 바뀌면 여기 한 곳만 고치면 된다.
+ */
+export async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+  const server = buildServer('0.0.0-test');
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'boot-smoke-test', version: '0.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  try {
+    return await fn(client);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}

--- a/packages/mcp-server/src/__tests__/prompts-resources.test.ts
+++ b/packages/mcp-server/src/__tests__/prompts-resources.test.ts
@@ -1,31 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { buildServer } from '../server.js';
-import type { ToolManifest } from '../resources.js';
+import { readToolManifest } from '../lib/package-root.js';
+import { withClient } from './helpers.js';
 
 // 프롬프트/리소스는 tool-manifest 의 대상이 아니므로 여기서 별도로 스모크한다.
 // 특히 mimi-seed://agent/guide 는 docs/agent-guide.md 의 "배포용 사본"(assets/)을 서빙하는데,
 // 사본이라 드리프트가 가능하다 — 이 테스트가 원본과의 바이트 동일성을 강제한다.
 
-const manifest = JSON.parse(
-  readFileSync(new URL('../../tool-manifest.json', import.meta.url), 'utf8'),
-) as ToolManifest;
-const manifestNames = new Set(Object.values(manifest.domains).flat());
-
-async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
-  const server = buildServer('0.0.0-test');
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const client = new Client({ name: 'prompts-resources-test', version: '0.0.0' });
-  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
-  try {
-    return await fn(client);
-  } finally {
-    await client.close();
-    await server.close();
-  }
-}
+const manifest = readToolManifest();
+const manifestNames = new Set(Object.values(manifest.domains).flatMap((d) => d.tools));
 
 describe('prompts & resources (boot smoke test)', () => {
   it('프롬프트 4종이 등록되어 있다', async () => {
@@ -75,18 +58,14 @@ describe('prompts & resources (boot smoke test)', () => {
       const catalogIds = catalog.domains.map((d) => d.id).sort();
       expect(catalogIds).toEqual(Object.keys(manifest.domains).sort());
 
-      // 도메인을 추가하면 resources.ts 의 DOMAIN_SUMMARY 에도 추가해야 한다.
-      const unsummarized = catalog.domains
-        .filter((d) => d.label === d.id || d.credential === '알 수 없음' || !d.summary)
-        .map((d) => d.id);
-      expect(
-        unsummarized,
-        `DOMAIN_SUMMARY 에 항목이 없는 도메인 — resources.ts 를 갱신하세요: ${unsummarized.join(', ')}`,
-      ).toEqual([]);
-
+      // 메타데이터는 manifest 가 SSOT — 리소스는 그대로 서빙해야 한다.
       for (const domain of catalog.domains) {
-        expect(domain.toolCount).toBe(manifest.domains[domain.id].length);
-        expect(domain.tools).toEqual(manifest.domains[domain.id]);
+        const entry = manifest.domains[domain.id];
+        expect(domain.label).toBe(entry.label);
+        expect(domain.credential).toBe(entry.credential);
+        expect(domain.summary).toBe(entry.summary);
+        expect(domain.toolCount).toBe(entry.tools.length);
+        expect(domain.tools).toEqual(entry.tools);
       }
     });
   });

--- a/packages/mcp-server/src/__tests__/tool-manifest.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-manifest.test.ts
@@ -1,33 +1,34 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { buildServer } from '../server.js';
+import { readToolManifest } from '../lib/package-root.js';
+import { withClient } from './helpers.js';
 
-// tool-manifest.json = 등록 도구 인벤토리의 SSOT.
+// tool-manifest.json = 등록 도구 인벤토리 + 도메인 메타데이터의 SSOT.
 // 이 테스트는 실제 McpServer 를 기동해(boot smoke test) 등록된 도구 목록을
 // manifest 와 diff 한다 — 도구 추가/삭제/개명이 manifest 갱신 없이 머지되는 것을 막고,
 // register 모듈이 server.ts 에서 빠지는 사고(과거 문서 카운트 드리프트의 근본 원인)도 잡는다.
-const manifest = JSON.parse(
-  readFileSync(new URL('../../tool-manifest.json', import.meta.url), 'utf8'),
-) as { total: number; domains: Record<string, string[]> };
+const manifest = readToolManifest();
 
-const manifestNames = Object.values(manifest.domains).flat();
+const manifestNames = Object.values(manifest.domains).flatMap((d) => d.tools);
 
 describe('tool-manifest (boot smoke test)', () => {
-  it('manifest 자체 정합성 — total 일치, 도메인 간 중복 없음', () => {
+  it('manifest 자체 정합성 — total 일치, 도메인 간 중복 없음, 메타데이터 완비', () => {
     expect(manifest.total).toBe(manifestNames.length);
     const dupes = manifestNames.filter((n, i) => manifestNames.indexOf(n) !== i);
     expect(dupes, `manifest 내 중복 도구: ${dupes.join(', ')}`).toEqual([]);
+
+    // 도메인 메타데이터는 mimi-seed://tools/catalog 리소스가 그대로 서빙한다 —
+    // 도메인을 추가하면 label/credential/summary 도 함께 채울 것.
+    const incomplete = Object.entries(manifest.domains)
+      .filter(([, d]) => !d.label?.trim() || !d.credential?.trim() || !d.summary?.trim())
+      .map(([id]) => id);
+    expect(
+      incomplete,
+      `label/credential/summary 가 비어 있는 도메인 — tool-manifest.json 을 채우세요: ${incomplete.join(', ')}`,
+    ).toEqual([]);
   });
 
   it('실제 서버 등록 목록 == manifest (추가/삭제/개명 시 tool-manifest.json 갱신 필수)', async () => {
-    const server = buildServer('0.0.0-test');
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    const client = new Client({ name: 'manifest-test', version: '0.0.0' });
-    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
-
-    try {
+    await withClient(async (client) => {
       const { tools } = await client.listTools();
       const live = tools.map((t) => t.name);
 
@@ -44,24 +45,14 @@ describe('tool-manifest (boot smoke test)', () => {
         untracked,
         `서버에 등록됐는데 manifest 에 없는 도구 — tool-manifest.json 에 추가하세요: ${untracked.join(', ')}`,
       ).toEqual([]);
-    } finally {
-      await client.close();
-      await server.close();
-    }
+    });
   });
 
   it('모든 도구에 비어 있지 않은 설명이 있다', async () => {
-    const server = buildServer('0.0.0-test');
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    const client = new Client({ name: 'manifest-test', version: '0.0.0' });
-    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
-    try {
+    await withClient(async (client) => {
       const { tools } = await client.listTools();
       const noDesc = tools.filter((t) => !t.description?.trim()).map((t) => t.name);
       expect(noDesc, `설명 없는 도구: ${noDesc.join(', ')}`).toEqual([]);
-    } finally {
-      await client.close();
-      await server.close();
-    }
+    });
   });
 });

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
-import { readFileSync } from 'node:fs';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { buildServer } from './server.js';
+import { readPackageRootText } from './lib/package-root.js';
 
-// dist/index.js 기준 ../package.json — npm 패키지 루트의 버전을 단일 출처로 사용.
+// npm 패키지 루트의 버전을 단일 출처로 사용.
 // 하드코딩하면 publish 때마다 serverInfo.version 이 드리프트하므로 런타임에 읽는다.
-const { version } = JSON.parse(
-  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
-) as { version: string };
+const { version } = JSON.parse(readPackageRootText('package.json')) as { version: string };
 
 // `npx -y @yoonion/mimi-seed-mcp <subcommand>` 처리.
 // npx는 스코프 패키지의 basename(`mimi-seed-mcp`)을 매치해 이 bin을 실행하므로,

--- a/packages/mcp-server/src/lib/package-root.ts
+++ b/packages/mcp-server/src/lib/package-root.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * 패키지 루트의 파일을 읽는다 (없거나 못 읽으면 throw).
+ * src/lib/ 와 dist/lib/ 모두 패키지 루트에서 두 단계 아래라 `../../` 가 같은 곳을 가리킨다 —
+ * dev(tsx)·vitest·배포본(npm) 어디서 실행해도 동일하게 동작한다.
+ * 개별 `new URL('../..', import.meta.url)` 복사본을 만들지 말고 이 헬퍼를 쓸 것
+ * (빌드 레이아웃이 바뀌면 여기 한 곳만 고치면 된다).
+ */
+export function readPackageRootText(relativePath: string): string {
+  return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+export type DomainEntry = {
+  /** 사람이 읽는 도메인 이름 (예: "Google Play") */
+  label: string;
+  /** 이 도메인을 쓰기 위해 필요한 자격증명 + 연결 명령 힌트 */
+  credential: string;
+  /** 도메인이 하는 일 한 줄 요약 */
+  summary: string;
+  tools: string[];
+};
+
+/** tool-manifest.json 의 형태 — 도구 인벤토리 + 도메인 메타데이터의 SSOT. */
+export type ToolManifest = { total: number; domains: Record<string, DomainEntry> };
+
+/** tool-manifest.json 을 읽고 최소 형태를 검증한다. 손상/형태이상이면 throw. */
+export function readToolManifest(): ToolManifest {
+  const manifest = JSON.parse(readPackageRootText('tool-manifest.json')) as ToolManifest;
+  if (
+    typeof manifest?.total !== 'number' ||
+    typeof manifest?.domains !== 'object' ||
+    manifest.domains === null
+  ) {
+    throw new Error('tool-manifest.json 의 형태가 예상과 다릅니다');
+  }
+  return manifest;
+}

--- a/packages/mcp-server/src/registers/auth.ts
+++ b/packages/mcp-server/src/registers/auth.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { getMcpOAuthClient } from '../auth/constants.js';
@@ -13,6 +12,7 @@ import { loadFacebookConfig } from '../facebook/config.js';
 import { loadInstagramConfig } from '../instagram/config.js';
 import { loadThreadsConfig } from '../threads/config.js';
 import { metaTokenFreshness } from '../lib/meta-auth.js';
+import { readPackageRootText } from '../lib/package-root.js';
 import { resolveBigQueryAuth } from '../auth/bigquery-auth.js';
 import { syncRemoteCredentials } from '../remote-sync.js';
 import {
@@ -82,9 +82,7 @@ const MANIFEST_FIX: Record<ManifestServiceId, (svc: ManifestService) => string> 
 
 // 두 MCP 가 모두 'mimi-seed' 로 등록되는 환경에서 에이전트가 프로그램적으로
 // 어느 서버인지 판별할 수 있도록 status 첫 줄에 자기소개를 넣는다.
-const { version: PKG_VERSION } = JSON.parse(
-  readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
-) as { version: string };
+const { version: PKG_VERSION } = JSON.parse(readPackageRootText('package.json')) as { version: string };
 
 /** 서비스별 식별자를 한 줄 detail 로 (예: "ads-coffee / analytics_530080532"). */
 function manifestServiceDetail(id: ManifestServiceId, svc: ManifestService): string {

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -1,9 +1,6 @@
-import { readFileSync } from 'node:fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ensureFreshAccessToken } from './auth/google-auth.js';
-
-/** tool-manifest.json 의 형태. 테스트들도 이 타입을 import 해 캐스트 드리프트를 막는다. */
-export type ToolManifest = { total: number; domains: Record<string, string[]> };
+import { readPackageRootText, readToolManifest } from './lib/package-root.js';
 
 // assets/agent-guide.md = docs/agent-guide.md 의 배포용 사본 (npm 배포본에는 docs/ 가 없다).
 // 갱신은 `npm run plugin:sync`, 드리프트는 prompts-resources.test.ts 가 잡는다.
@@ -18,110 +15,6 @@ const AGENT_GUIDE_FALLBACK = [
   '가이드 전문: https://github.com/jeonghwanko/mimi-seed-sdk/blob/main/docs/agent-guide.md',
   '최소 안전수칙: 스토어 제출·승격·삭제·공개 게시는 사용자 명시 동의 없이 실행하지 않는다.',
 ].join('\n');
-
-function readPackageAsset(relativePath: string): string | null {
-  try {
-    // src/ 와 dist/ 모두 패키지 루트 바로 아래라 ../ 가 같은 곳을 가리킨다 (index.ts 의 package.json 읽기와 동일 패턴).
-    return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
-  } catch {
-    return null;
-  }
-}
-
-/** 도메인 id → 라벨·필요 자격증명·한줄 요약. 키 집합은 tool-manifest.json 의 domains 와
- *  일치해야 한다 (prompts-resources.test.ts 가 강제) — 도메인을 추가하면 여기도 추가할 것. */
-const DOMAIN_SUMMARY: Record<string, { label: string; credential: string; summary: string }> = {
-  playstore: {
-    label: 'Google Play',
-    credential: 'Google OAuth (CI/헤드리스는 Play 서비스 계정)',
-    summary: '리스팅·트랙 릴리스·이미지·리뷰 답변·통계·서비스 계정 등록',
-  },
-  appstore: {
-    label: 'App Store Connect',
-    credential: 'ASC API 키 (mimi-seed auth appstore)',
-    summary: '버전·빌드 attach·What\'s New·스크린샷·IAP 심사 메타데이터·심사 제출',
-  },
-  firebase: {
-    label: 'Firebase',
-    credential: 'Google OAuth',
-    summary: '프로젝트/앱 생성·설정 파일 다운로드·서비스 활성화',
-  },
-  admob: {
-    label: 'AdMob',
-    credential: 'Google OAuth',
-    summary: '앱·광고 단위 생성, 오늘 수익·기간 리포트',
-  },
-  iam: {
-    label: 'Google Cloud IAM',
-    credential: 'Google OAuth',
-    summary: '서비스 계정 생성·키 발급·IAM 정책 바인딩',
-  },
-  bigquery: {
-    label: 'BigQuery',
-    credential: 'Google OAuth (또는 BigQuery 서비스 계정)',
-    summary: '쿼리 실행·데이터셋/테이블/스키마 조회',
-  },
-  ga4: {
-    label: 'Google Analytics 4',
-    credential: 'Google OAuth',
-    summary: '계정/속성·데이터 스트림 관리, 리포트 실행',
-  },
-  gsc: {
-    label: 'Search Console',
-    credential: 'Google OAuth',
-    summary: 'URL 검사·검색 성과 분석·사이트맵 제출',
-  },
-  googleads: {
-    label: 'Google Ads',
-    credential: 'Google Ads 설정 (mimi-seed auth googleads, adwords 스코프)',
-    summary: '캠페인 목록·캠페인/UAC 리포트',
-  },
-  ci: {
-    label: 'CI (GitHub Actions / GitLab)',
-    credential: 'GitHub/GitLab 토큰 (mimi-seed auth ci)',
-    summary: '워크플로 조회·빌드 트리거/상태/취소 — Jenkins 빌드는 대상 아님',
-  },
-  jenkins: {
-    label: 'Jenkins',
-    credential: 'Jenkins URL + API 토큰 (mimi-seed auth jenkins)',
-    summary: '크리덴셜·keystore 업로드·잡 생성/수정 — 빌드 트리거 도구는 없음',
-  },
-  android: {
-    label: 'Android 서명',
-    credential: '없음 (로컬 파일 작업)',
-    summary: 'keystore 생성·서명 설정·Jenkins 로 Play SA 업로드',
-  },
-  facebook: {
-    label: 'Facebook',
-    credential: 'Facebook 페이지 토큰 (mimi-seed auth facebook)',
-    summary: '페이지 텍스트/사진/링크 포스팅',
-  },
-  instagram: {
-    label: 'Instagram',
-    credential: 'Instagram 토큰 (mimi-seed auth instagram)',
-    summary: '사진·캐러셀·릴스 포스팅',
-  },
-  threads: {
-    label: 'Threads',
-    credential: 'Threads 토큰 (mimi-seed auth threads)',
-    summary: '텍스트/이미지 포스팅·토큰 갱신',
-  },
-  checks: {
-    label: '출시 점검',
-    credential: '점검 대상 스토어의 자격증명',
-    summary: '제출 전 위험 점검·스크린샷 규격 검증·릴리스 상태',
-  },
-  ai: {
-    label: 'AI 생성',
-    credential: 'ANTHROPIC_API_KEY 환경변수',
-    summary: '커밋 기반 릴리스 노트·리뷰 답변 초안 생성',
-  },
-  auth: {
-    label: '연결/진단',
-    credential: '없음 (이것이 셋업 도구)',
-    summary: '전체 연결 상태 스캔(mimi_seed_status)·OAuth 시작·원격 크리덴셜 동기화',
-  },
-};
 
 export function registerResources(server: McpServer) {
   server.resource(
@@ -154,13 +47,21 @@ export function registerResources(server: McpServer) {
       description: 'Mimi Seed 에이전트 운영 규약 전문 (docs/agent-guide.md) — deferred 도구 로딩·ToolSearch select: 배치·호출 순서·비가역 액션 안전수칙',
       mimeType: 'text/markdown',
     },
-    async () => ({
-      contents: [{
-        uri: 'mimi-seed://agent/guide',
-        mimeType: 'text/markdown',
-        text: readPackageAsset('../assets/agent-guide.md') ?? AGENT_GUIDE_FALLBACK,
-      }],
-    }),
+    async () => {
+      let text: string;
+      try {
+        text = readPackageRootText('assets/agent-guide.md');
+      } catch {
+        text = AGENT_GUIDE_FALLBACK;
+      }
+      return {
+        contents: [{
+          uri: 'mimi-seed://agent/guide',
+          mimeType: 'text/markdown',
+          text,
+        }],
+      };
+    },
   );
 
   server.resource(
@@ -172,24 +73,22 @@ export function registerResources(server: McpServer) {
     },
     async () => {
       // LLM 이 읽는 페이로드라 compact 로 직렬화한다 (pretty 들여쓰기는 ~40% 바이트 낭비).
+      // 도메인 메타데이터(label·credential·summary)는 tool-manifest.json 이 SSOT —
+      // 여기서는 그대로 서빙만 한다.
       let payload: string;
       try {
-        const raw = readFileSync(new URL('../tool-manifest.json', import.meta.url), 'utf8');
-        const manifest = JSON.parse(raw) as ToolManifest;
-        if (typeof manifest?.total !== 'number' || typeof manifest?.domains !== 'object' || manifest.domains === null) {
-          throw new Error('tool-manifest.json 의 형태가 예상과 다릅니다');
-        }
+        const manifest = readToolManifest();
         payload = JSON.stringify({
           total: manifest.total,
           deferredHint:
             'Claude Code 에서는 도구 schema 가 lazy 로드됩니다 — 호출 전 ToolSearch(query="select:<tool,...>") 로 선로드하세요. 상세: mimi-seed://agent/guide',
-          domains: Object.entries(manifest.domains).map(([id, tools]) => ({
+          domains: Object.entries(manifest.domains).map(([id, d]) => ({
             id,
-            label: DOMAIN_SUMMARY[id]?.label ?? id,
-            credential: DOMAIN_SUMMARY[id]?.credential ?? '알 수 없음',
-            summary: DOMAIN_SUMMARY[id]?.summary ?? '',
-            toolCount: tools.length,
-            tools,
+            label: d.label,
+            credential: d.credential,
+            summary: d.summary,
+            toolCount: d.tools.length,
+            tools: d.tools,
           })),
         });
       } catch (e) {

--- a/packages/mcp-server/tool-manifest.json
+++ b/packages/mcp-server/tool-manifest.json
@@ -1,205 +1,295 @@
 {
-  "$comment": "등록된 MCP 도구의 SSOT. src/__tests__/tool-manifest.test.ts 가 실제 서버 등록 목록과 diff 하여 강제한다. 도구 추가/삭제/개명 시 이 파일을 함께 갱신할 것 — 산문 문서에는 정확한 개수를 쓰지 말고 이 파일을 가리킬 것.",
+  "$comment": "등록된 MCP 도구 + 도메인 메타데이터(label·credential·summary)의 SSOT. src/__tests__/tool-manifest.test.ts 가 실제 서버 등록 목록과 diff 하고 메타데이터 정합성을 검사한다. 도구 추가/삭제/개명 시 이 파일을 함께 갱신할 것 — 산문 문서에는 정확한 개수를 쓰지 말고 이 파일을 가리킬 것. mimi-seed://tools/catalog 리소스가 이 파일을 그대로 서빙한다.",
   "total": 163,
   "domains": {
-    "admob": [
-      "admob_list_accounts",
-      "admob_list_apps",
-      "admob_list_ad_units",
-      "admob_get_today_earnings",
-      "admob_get_report",
-      "admob_create_app",
-      "admob_create_ad_unit"
-    ],
-    "ai": [
-      "generate_release_notes_from_commits",
-      "generate_review_reply"
-    ],
-    "android": [
-      "android_signing_setup",
-      "android_generate_keystore",
-      "jenkins_upload_playstore_sa"
-    ],
-    "appstore": [
-      "appstore_list_apps",
-      "appstore_verify_credentials",
-      "appstore_get_app",
-      "appstore_list_versions",
-      "appstore_create_version",
-      "appstore_attach_build",
-      "appstore_attach_latest_build",
-      "appstore_get_metadata",
-      "appstore_update_localization",
-      "appstore_list_screenshots",
-      "appstore_upload_screenshot",
-      "appstore_delete_screenshot",
-      "appstore_delete_screenshot_set",
-      "appstore_update_whats_new",
-      "appstore_update_review_notes",
-      "appstore_get_review_notes",
-      "appstore_list_builds",
-      "appstore_list_beta_groups",
-      "appstore_get_app_info",
-      "appstore_list_app_info_localizations",
-      "appstore_update_app_info_localization",
-      "appstore_create_app_info_localization",
-      "appstore_list_reviews",
-      "appstore_reply_review",
-      "appstore_create_inapp_purchase",
-      "appstore_create_subscription",
-      "appstore_list_products",
-      "appstore_update_product_review_note",
-      "appstore_upload_product_review_screenshot",
-      "appstore_update_product",
-      "appstore_delete_product",
-      "appstore_plan_release",
-      "appstore_submit_for_review",
-      "appstore_cancel_review"
-    ],
-    "auth": [
-      "mimi_seed_status",
-      "mimi_seed_auth_start",
-      "mimi_seed_auth_status",
-      "mimi_seed_remote_sync_credentials"
-    ],
-    "bigquery": [
-      "bigquery_run_query",
-      "bigquery_list_datasets",
-      "bigquery_list_tables",
-      "bigquery_get_table_schema",
-      "bigquery_auth_status"
-    ],
-    "checks": [
-      "playstore_check_submission_risks",
-      "appstore_check_submission_risks",
-      "screenshot_validate",
-      "release_status"
-    ],
-    "ci": [
-      "ci_save_config",
-      "ci_list_workflows",
-      "ci_trigger_build",
-      "ci_get_build_status",
-      "ci_list_recent_builds",
-      "ci_cancel_build"
-    ],
-    "facebook": [
-      "facebook_save_config",
-      "facebook_list_pages",
-      "facebook_get_page",
-      "facebook_post_photo",
-      "facebook_post_multi_photo",
-      "facebook_current_config"
-    ],
-    "firebase": [
-      "firebase_list_projects",
-      "firebase_get_project",
-      "firebase_create_project",
-      "firebase_list_android_apps",
-      "firebase_create_android_app",
-      "firebase_get_android_config",
-      "firebase_delete_android_app",
-      "firebase_list_ios_apps",
-      "firebase_create_ios_app",
-      "firebase_get_ios_config",
-      "firebase_delete_ios_app",
-      "firebase_list_web_apps",
-      "firebase_create_web_app",
-      "firebase_get_web_config",
-      "firebase_delete_web_app",
-      "firebase_enable_service",
-      "firebase_enable_common_services",
-      "firebase_list_enabled_services",
-      "firebase_link_analytics",
-      "firebase_get_analytics_details"
-    ],
-    "ga4": [
-      "ga4_list_account_summaries",
-      "ga4_list_properties",
-      "ga4_create_property",
-      "ga4_create_data_stream",
-      "ga4_list_data_streams",
-      "ga4_run_report"
-    ],
-    "googleads": [
-      "googleads_save_config",
-      "googleads_list_campaigns",
-      "googleads_get_campaign_report",
-      "googleads_get_uac_report",
-      "googleads_list_accessible_customers",
-      "googleads_config_status"
-    ],
-    "gsc": [
-      "gsc_list_sites",
-      "gsc_list_sitemaps",
-      "gsc_get_sitemap",
-      "gsc_submit_sitemap",
-      "gsc_inspect_url",
-      "gsc_search_analytics"
-    ],
-    "iam": [
-      "iam_list_service_accounts",
-      "iam_create_service_account",
-      "iam_list_keys",
-      "iam_create_key",
-      "iam_add_iam_policy_binding"
-    ],
-    "instagram": [
-      "instagram_save_config",
-      "instagram_get_account",
-      "instagram_post_image",
-      "instagram_post_carousel"
-    ],
-    "jenkins": [
-      "jenkins_status",
-      "jenkins_save_config",
-      "jenkins_list_credentials",
-      "jenkins_create_credential",
-      "jenkins_upload_keystore",
-      "jenkins_delete_credential",
-      "jenkins_list_jobs",
-      "jenkins_get_job_config",
-      "jenkins_create_job",
-      "jenkins_update_job"
-    ],
-    "playstore": [
-      "playstore_get_app",
-      "playstore_update_details",
-      "playstore_get_listing",
-      "playstore_update_listing",
-      "playstore_list_tracks",
-      "playstore_get_statistics",
-      "playstore_list_images",
-      "playstore_upload_image",
-      "playstore_delete_all_images",
-      "playstore_replace_images",
-      "playstore_update_release_notes",
-      "playstore_update_latest_release_notes",
-      "playstore_list_reviews",
-      "playstore_reply_review",
-      "playstore_list_inapp_products",
-      "playstore_list_subscriptions",
-      "playstore_create_onetime_product",
-      "playstore_create_subscription",
-      "playstore_verify_service_account",
-      "playstore_register_service_account",
-      "playstore_list_service_accounts",
-      "playstore_delete_service_account",
-      "playstore_plan_release",
-      "playstore_submit_release",
-      "playstore_promote_release",
-      "playstore_list_products",
-      "playstore_update_product",
-      "playstore_delete_product",
-      "setup_playstore_connection"
-    ],
-    "threads": [
-      "threads_save_config",
-      "threads_refresh_token",
-      "threads_get_account",
-      "threads_post",
-      "threads_post_carousel",
-      "threads_current_config"
-    ]
+    "admob": {
+      "label": "AdMob",
+      "credential": "Google OAuth",
+      "summary": "앱·광고 단위 생성, 오늘 수익·기간 리포트",
+      "tools": [
+        "admob_list_accounts",
+        "admob_list_apps",
+        "admob_list_ad_units",
+        "admob_get_today_earnings",
+        "admob_get_report",
+        "admob_create_app",
+        "admob_create_ad_unit"
+      ]
+    },
+    "ai": {
+      "label": "AI 생성",
+      "credential": "ANTHROPIC_API_KEY 환경변수",
+      "summary": "커밋 기반 릴리스 노트·리뷰 답변 초안 생성",
+      "tools": [
+        "generate_release_notes_from_commits",
+        "generate_review_reply"
+      ]
+    },
+    "android": {
+      "label": "Android 서명",
+      "credential": "없음 (로컬 파일 작업)",
+      "summary": "keystore 생성·서명 설정·Jenkins 로 Play SA 업로드",
+      "tools": [
+        "android_signing_setup",
+        "android_generate_keystore",
+        "jenkins_upload_playstore_sa"
+      ]
+    },
+    "appstore": {
+      "label": "App Store Connect",
+      "credential": "ASC API 키 (mimi-seed auth appstore)",
+      "summary": "버전·빌드 attach·What's New·스크린샷·IAP 심사 메타데이터·심사 제출",
+      "tools": [
+        "appstore_list_apps",
+        "appstore_verify_credentials",
+        "appstore_get_app",
+        "appstore_list_versions",
+        "appstore_create_version",
+        "appstore_attach_build",
+        "appstore_attach_latest_build",
+        "appstore_get_metadata",
+        "appstore_update_localization",
+        "appstore_list_screenshots",
+        "appstore_upload_screenshot",
+        "appstore_delete_screenshot",
+        "appstore_delete_screenshot_set",
+        "appstore_update_whats_new",
+        "appstore_update_review_notes",
+        "appstore_get_review_notes",
+        "appstore_list_builds",
+        "appstore_list_beta_groups",
+        "appstore_get_app_info",
+        "appstore_list_app_info_localizations",
+        "appstore_update_app_info_localization",
+        "appstore_create_app_info_localization",
+        "appstore_list_reviews",
+        "appstore_reply_review",
+        "appstore_create_inapp_purchase",
+        "appstore_create_subscription",
+        "appstore_list_products",
+        "appstore_update_product_review_note",
+        "appstore_upload_product_review_screenshot",
+        "appstore_update_product",
+        "appstore_delete_product",
+        "appstore_plan_release",
+        "appstore_submit_for_review",
+        "appstore_cancel_review"
+      ]
+    },
+    "auth": {
+      "label": "연결/진단",
+      "credential": "없음 (이것이 셋업 도구)",
+      "summary": "전체 연결 상태 스캔(mimi_seed_status)·OAuth 시작·원격 크리덴셜 동기화",
+      "tools": [
+        "mimi_seed_status",
+        "mimi_seed_auth_start",
+        "mimi_seed_auth_status",
+        "mimi_seed_remote_sync_credentials"
+      ]
+    },
+    "bigquery": {
+      "label": "BigQuery",
+      "credential": "Google OAuth (또는 BigQuery 서비스 계정)",
+      "summary": "쿼리 실행·데이터셋/테이블/스키마 조회",
+      "tools": [
+        "bigquery_run_query",
+        "bigquery_list_datasets",
+        "bigquery_list_tables",
+        "bigquery_get_table_schema",
+        "bigquery_auth_status"
+      ]
+    },
+    "checks": {
+      "label": "출시 점검",
+      "credential": "점검 대상 스토어의 자격증명",
+      "summary": "제출 전 위험 점검·스크린샷 규격 검증·릴리스 상태",
+      "tools": [
+        "playstore_check_submission_risks",
+        "appstore_check_submission_risks",
+        "screenshot_validate",
+        "release_status"
+      ]
+    },
+    "ci": {
+      "label": "CI (GitHub Actions / GitLab)",
+      "credential": "GitHub/GitLab 토큰 (mimi-seed auth ci)",
+      "summary": "워크플로 조회·빌드 트리거/상태/취소 — Jenkins 빌드는 대상 아님",
+      "tools": [
+        "ci_save_config",
+        "ci_list_workflows",
+        "ci_trigger_build",
+        "ci_get_build_status",
+        "ci_list_recent_builds",
+        "ci_cancel_build"
+      ]
+    },
+    "facebook": {
+      "label": "Facebook",
+      "credential": "Facebook 페이지 토큰 (mimi-seed auth facebook)",
+      "summary": "페이지 텍스트/사진/링크 포스팅",
+      "tools": [
+        "facebook_save_config",
+        "facebook_list_pages",
+        "facebook_get_page",
+        "facebook_post_photo",
+        "facebook_post_multi_photo",
+        "facebook_current_config"
+      ]
+    },
+    "firebase": {
+      "label": "Firebase",
+      "credential": "Google OAuth",
+      "summary": "프로젝트/앱 생성·설정 파일 다운로드·서비스 활성화",
+      "tools": [
+        "firebase_list_projects",
+        "firebase_get_project",
+        "firebase_create_project",
+        "firebase_list_android_apps",
+        "firebase_create_android_app",
+        "firebase_get_android_config",
+        "firebase_delete_android_app",
+        "firebase_list_ios_apps",
+        "firebase_create_ios_app",
+        "firebase_get_ios_config",
+        "firebase_delete_ios_app",
+        "firebase_list_web_apps",
+        "firebase_create_web_app",
+        "firebase_get_web_config",
+        "firebase_delete_web_app",
+        "firebase_enable_service",
+        "firebase_enable_common_services",
+        "firebase_list_enabled_services",
+        "firebase_link_analytics",
+        "firebase_get_analytics_details"
+      ]
+    },
+    "ga4": {
+      "label": "Google Analytics 4",
+      "credential": "Google OAuth",
+      "summary": "계정/속성·데이터 스트림 관리, 리포트 실행",
+      "tools": [
+        "ga4_list_account_summaries",
+        "ga4_list_properties",
+        "ga4_create_property",
+        "ga4_create_data_stream",
+        "ga4_list_data_streams",
+        "ga4_run_report"
+      ]
+    },
+    "googleads": {
+      "label": "Google Ads",
+      "credential": "Google Ads 설정 (mimi-seed auth googleads, adwords 스코프)",
+      "summary": "캠페인 목록·캠페인/UAC 리포트",
+      "tools": [
+        "googleads_save_config",
+        "googleads_list_campaigns",
+        "googleads_get_campaign_report",
+        "googleads_get_uac_report",
+        "googleads_list_accessible_customers",
+        "googleads_config_status"
+      ]
+    },
+    "gsc": {
+      "label": "Search Console",
+      "credential": "Google OAuth",
+      "summary": "URL 검사·검색 성과 분석·사이트맵 제출",
+      "tools": [
+        "gsc_list_sites",
+        "gsc_list_sitemaps",
+        "gsc_get_sitemap",
+        "gsc_submit_sitemap",
+        "gsc_inspect_url",
+        "gsc_search_analytics"
+      ]
+    },
+    "iam": {
+      "label": "Google Cloud IAM",
+      "credential": "Google OAuth",
+      "summary": "서비스 계정 생성·키 발급·IAM 정책 바인딩",
+      "tools": [
+        "iam_list_service_accounts",
+        "iam_create_service_account",
+        "iam_list_keys",
+        "iam_create_key",
+        "iam_add_iam_policy_binding"
+      ]
+    },
+    "instagram": {
+      "label": "Instagram",
+      "credential": "Instagram 토큰 (mimi-seed auth instagram)",
+      "summary": "사진·캐러셀·릴스 포스팅",
+      "tools": [
+        "instagram_save_config",
+        "instagram_get_account",
+        "instagram_post_image",
+        "instagram_post_carousel"
+      ]
+    },
+    "jenkins": {
+      "label": "Jenkins",
+      "credential": "Jenkins URL + API 토큰 (mimi-seed auth jenkins)",
+      "summary": "크리덴셜·keystore 업로드·잡 생성/수정 — 빌드 트리거 도구는 없음",
+      "tools": [
+        "jenkins_status",
+        "jenkins_save_config",
+        "jenkins_list_credentials",
+        "jenkins_create_credential",
+        "jenkins_upload_keystore",
+        "jenkins_delete_credential",
+        "jenkins_list_jobs",
+        "jenkins_get_job_config",
+        "jenkins_create_job",
+        "jenkins_update_job"
+      ]
+    },
+    "playstore": {
+      "label": "Google Play",
+      "credential": "Google OAuth (CI/헤드리스는 Play 서비스 계정)",
+      "summary": "리스팅·트랙 릴리스·이미지·리뷰 답변·통계·서비스 계정 등록",
+      "tools": [
+        "playstore_get_app",
+        "playstore_update_details",
+        "playstore_get_listing",
+        "playstore_update_listing",
+        "playstore_list_tracks",
+        "playstore_get_statistics",
+        "playstore_list_images",
+        "playstore_upload_image",
+        "playstore_delete_all_images",
+        "playstore_replace_images",
+        "playstore_update_release_notes",
+        "playstore_update_latest_release_notes",
+        "playstore_list_reviews",
+        "playstore_reply_review",
+        "playstore_list_inapp_products",
+        "playstore_list_subscriptions",
+        "playstore_create_onetime_product",
+        "playstore_create_subscription",
+        "playstore_verify_service_account",
+        "playstore_register_service_account",
+        "playstore_list_service_accounts",
+        "playstore_delete_service_account",
+        "playstore_plan_release",
+        "playstore_submit_release",
+        "playstore_promote_release",
+        "playstore_list_products",
+        "playstore_update_product",
+        "playstore_delete_product",
+        "setup_playstore_connection"
+      ]
+    },
+    "threads": {
+      "label": "Threads",
+      "credential": "Threads 토큰 (mimi-seed auth threads)",
+      "summary": "텍스트/이미지 포스팅·토큰 갱신",
+      "tools": [
+        "threads_save_config",
+        "threads_refresh_token",
+        "threads_get_account",
+        "threads_post",
+        "threads_post_carousel",
+        "threads_current_config"
+      ]
+    }
   }
 }

--- a/plugins/mimi-seed/docs/domain/architecture.md
+++ b/plugins/mimi-seed/docs/domain/architecture.md
@@ -119,8 +119,8 @@ Registered in `mcp-server/src/resources.ts` and `prompts.ts`:
 
 - **Resources** — `mimi-seed://auth/status` (Google OAuth freshness as JSON), `mimi-seed://agent/guide`
   (the full `docs/agent-guide.md`, served from the committed copy `packages/mcp-server/assets/agent-guide.md`
-  — refreshed by `npm run plugin:sync`), and `mimi-seed://tools/catalog` (runtime capability index derived
-  from `tool-manifest.json` + the `DOMAIN_SUMMARY` map in `resources.ts`).
+  — refreshed by `npm run plugin:sync`), and `mimi-seed://tools/catalog` (runtime capability index served
+  verbatim from `tool-manifest.json`, which carries per-domain `label`/`credential`/`summary` metadata).
 - **Prompts → slash commands** — `getting-started`, `deploy`, `health`, `review-inbox`, surfaced in MCP
   clients as `/mimi-seed:<name>`. More in [[skills-plugins]].
 

--- a/plugins/mimi-seed/docs/domain/skills-plugins.md
+++ b/plugins/mimi-seed/docs/domain/skills-plugins.md
@@ -56,7 +56,8 @@ Exposed by the MCP server (`prompts.ts` / `resources.ts`, see [[architecture]]):
   [`docs/agent-guide.md`](../agent-guide.md), served from the committed copy `packages/mcp-server/assets/agent-guide.md`
   — refreshed by `npm run plugin:sync`, drift-guarded by `prompts-resources.test.ts`), and
   `mimi-seed://tools/catalog` (runtime capability index: every tool by domain with the credential each domain
-  needs, derived from `tool-manifest.json` + the `DOMAIN_SUMMARY` map in `resources.ts`).
+  needs, served verbatim from `tool-manifest.json` — the manifest carries the per-domain
+  `label`/`credential`/`summary` metadata, integrity-checked by `tool-manifest.test.ts`).
 
 These are available in **any** MCP client, independent of the skills (which are a Claude Code / Codex packaging
 concept).


### PR DESCRIPTION
## Why

Deferred follow-ups from the v0.11.0 adversarial review (PR #11):

- `DOMAIN_SUMMARY` in `resources.ts` was an 18-key hand-written mirror of domain knowledge sitting *beside* `tool-manifest.json` — guarded only by a key-set test, so content drift (stale credential hints, wrong capability claims) could ship silently.
- The manifest's type literal was hand-copied in 4 files; the `new URL('../..', import.meta.url)` package-root trick in 3; the InMemoryTransport boot ritual in 3.

## What

**One file now owns the domain axis.** `tool-manifest.json` domains are promoted from `string[]` to `{label, credential, summary, tools}`:

- `mimi-seed://tools/catalog` serves the manifest **verbatim** — the `DOMAIN_SUMMARY` map and its `'알 수 없음'` fallbacks are deleted. Adding a domain is a one-file edit.
- `tool-manifest.test.ts` now enforces metadata completeness — a blank `label`/`credential`/`summary` fails CI (negative-tested: blanked a summary → 2 tests fail → restore → green).
- New `src/lib/package-root.ts`: `readPackageRootText()` consolidates the three inline package-root reads (`resources.ts`, `index.ts`, `registers/auth.ts`) so the src/dist layout assumption lives in one place; exports `ToolManifest`/`readToolManifest()` reused by all three manifest-reading tests.
- New `src/__tests__/helpers.ts`: shared `withClient()` boot/teardown (was three inline copies).
- `docs/domain/{architecture,skills-plugins}.md` updated to describe the manifest-carried metadata.

## Behavior

**None changed.** The catalog resource payload is identical in shape and content (`prompts-resources.test.ts` asserts the served fields equal the manifest entries field-by-field). No version bump — this ships with the next release.

## Verification

- Root `npm test` green: mcp-server **229**, cli **134**, `plugin:check` (incl. agent-guide asset check).
- Metadata guard negative-tested (blank summary → CI fails).
- `docs-drift.test.ts` still enforces manifest ↔ tool-catalog.md counts under the new schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)