### PR TITLE
feat: domain-selective (incremental) Google OAuth — v0.12.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed",
   "displayName": "Mimi Seed",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Claude Code에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Codex에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -80,13 +80,13 @@ every credential, which also tells them where to obtain each token
 
 | Service | Fix |
 |---------|-----|
-| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login` |
+| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login`. Both accept a **domain subset** (`domains=["ga4","googleads"]` / `--domains ga4,googleads`) — request only what the task needs; re-auth keeps prior grants (incremental). Omit for all domains |
 | App Store Connect | `mimi-seed auth appstore` → verify with `appstore_verify_credentials` |
 | Play service account | `mimi-seed auth playstore`, or register per-package with `playstore_register_service_account`. **Optional** — the OAuth token carries `androidpublisher`, so this is only needed for headless/CI |
 | BigQuery | `mimi-seed auth bigquery` (optional — OAuth works too) |
 | Jenkins | `mimi-seed auth jenkins` (probes the server before saving) |
 | GitHub / GitLab CI | `mimi-seed auth ci` |
-| Google Ads | `mimi-seed auth googleads` — needs the `adwords` OAuth scope; an old token may need `mimi-seed auth login --force` |
+| Google Ads | `mimi-seed auth googleads` — needs the `adwords` OAuth scope; an old token may need `mimi-seed auth login --domains googleads` (adds the grant, keeps the rest) |
 | Facebook / Instagram / Threads | `mimi-seed auth facebook` / `mimi-seed auth instagram` / `mimi-seed auth threads` |
 
 `mimi-seed auth meta` opens the combined social setup entry point when the user wants to review or reconnect

--- a/docs/domain/auth-credentials.md
+++ b/docs/domain/auth-credentials.md
@@ -52,6 +52,24 @@ All under `~/.mimi-seed/` (legacy `~/.preseed/` is still read as a fallback):
   metadata research, `PEXELS_API_KEY` for stock search, and `OPENAI_API_KEY` for generated images. Rendering
   itself is local and needs FFmpeg on `PATH` or `MIMI_SEED_FFMPEG_PATH`.
 
+## Domain-selective (incremental) Google OAuth
+
+The Google OAuth login no longer forces the full scope list. The SSOT for the **auth-domain → scope**
+mapping is `mcp-server/src/auth/scopes.ts` (`AUTH_DOMAINS`: `firebase`, `gcp`, `admob`, `playstore`,
+`googleads`, `gsc`, `ga4`) — least-privilege consent for the OAuth verification "minimum scopes" requirement:
+
+- `mimi-seed-auth --domains ga4,googleads` (CLI) and `mimi_seed_auth_start(domains=[…])` (MCP) request only
+  the selected domains' scopes; omitting the option requests everything (old behavior).
+- Requests are sent with `include_granted_scopes=true`, so a re-login **adds** the new scopes on top of the
+  existing grant instead of replacing it. `tokens.json` stores the cumulative granted `scope` string.
+- `requireAuth(<scope>)` in `helpers.ts` pre-flights a tool's required scope against the stored grant and, on
+  a miss, tells the user exactly which `--domains <id>` to add. Legacy tokens with no `scope` field are
+  assumed to hold every pre-tracking scope (only the GA4 scopes postdate scope tracking) so existing users
+  are not forced into a pointless re-login.
+- `cloud-platform` is isolated in the `gcp` domain because the IAM API offers no narrower scope; the
+  `firebase` domain alone cannot create projects (Cloud Resource Manager) or enable services (Service
+  Usage) — those tools pre-flight `cloud-platform` and point at `gcp`.
+
 ## Setup sub-CLIs
 
 Each setup flow is both a `bin` in `mcp-server/package.json` and an entry in the `SUBCOMMANDS` map

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed-sdk",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Monorepo root — the SDK version (SSOT for both packages and client plugin manifests) plus bootstrap scripts. The publishable packages live in packages/. This is NOT an npm workspace: each package installs independently.",
   "type": "module",
   "engines": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Mimi Seed CLI — Claude Code와 Codex에서 앱 출시 운영을 관리합니다.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -46,6 +46,7 @@ ${kleur.bold("한 번에 다 연결:")}
   ${kleur.cyan("mimi-seed setup")}             안내를 따라가며 순서대로 연결 (권장)
 
 ${kleur.bold("login 옵션:")}
+  --domains <ids>  요청할 권한 도메인만 선택 (쉼표 구분, 예: ga4,googleads — 기존 권한 유지)
   --no-browser     URL 자동 오픈 안 함 (직접 복붙)
   --timeout <초>   콜백 대기 시간 (기본 600)
   --force          기존 토큰 무시하고 강제 재로그인
@@ -83,6 +84,7 @@ ${kleur.bold("Connect them all in one pass:")}
   ${kleur.cyan("mimi-seed setup")}             guided, one credential at a time (recommended)
 
 ${kleur.bold("login options:")}
+  --domains <ids>  request only these permission domains (comma-separated, e.g. ga4,googleads — prior grants are kept)
   --no-browser     don't open the URL automatically (paste it yourself)
   --timeout <sec>  how long to wait for the callback (default 600)
   --force          ignore the existing token and sign in again
@@ -158,6 +160,10 @@ export async function cmdAuth(args: string[]): Promise<void> {
   }
 
   // 기본 Google OAuth (mimi-seed-auth)
+  // `mimi-seed auth --domains ga4` 처럼 서브명령 없이 플래그부터 시작하면 login 으로 위임.
+  if (sub?.startsWith("--")) {
+    return void exitWith(await runMcpBin("mimi-seed-auth", args));
+  }
   let mcpArgs: string[];
   switch (sub) {
     case undefined:

--- a/packages/mcp-server/assets/agent-guide.md
+++ b/packages/mcp-server/assets/agent-guide.md
@@ -80,13 +80,13 @@ every credential, which also tells them where to obtain each token
 
 | Service | Fix |
 |---------|-----|
-| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login` |
+| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login`. Both accept a **domain subset** (`domains=["ga4","googleads"]` / `--domains ga4,googleads`) — request only what the task needs; re-auth keeps prior grants (incremental). Omit for all domains |
 | App Store Connect | `mimi-seed auth appstore` → verify with `appstore_verify_credentials` |
 | Play service account | `mimi-seed auth playstore`, or register per-package with `playstore_register_service_account`. **Optional** — the OAuth token carries `androidpublisher`, so this is only needed for headless/CI |
 | BigQuery | `mimi-seed auth bigquery` (optional — OAuth works too) |
 | Jenkins | `mimi-seed auth jenkins` (probes the server before saving) |
 | GitHub / GitLab CI | `mimi-seed auth ci` |
-| Google Ads | `mimi-seed auth googleads` — needs the `adwords` OAuth scope; an old token may need `mimi-seed auth login --force` |
+| Google Ads | `mimi-seed auth googleads` — needs the `adwords` OAuth scope; an old token may need `mimi-seed auth login --domains googleads` (adds the grant, keeps the rest) |
 | Facebook / Instagram / Threads | `mimi-seed auth facebook` / `mimi-seed auth instagram` / `mimi-seed auth threads` |
 
 `mimi-seed auth meta` opens the combined social setup entry point when the user wants to review or reconnect

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Mimi Seed MCP server — Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/__tests__/auth-scopes.test.ts
+++ b/packages/mcp-server/src/__tests__/auth-scopes.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AUTH_DOMAINS,
+  ALL_SCOPES,
+  DOMAIN_IDS,
+  CLOUD_PLATFORM_SCOPE,
+  scopesForDomains,
+  domainsForScope,
+  parseDomainList,
+  summarizeGrantedDomains,
+  isPreTrackingScope,
+  mergeScopeStrings,
+} from '../auth/scopes.js';
+
+describe('auth/scopes — 도메인 → 스코프 매핑 SSOT', () => {
+  it('ALL_SCOPES 는 선택형 도입 전 full-scope 목록과 정확히 일치한다 (스코프 무단 증감 방지)', () => {
+    // OAuth 앱 심사(verification) 대상 목록이기도 하다 — 여기서 스코프가 소리 없이
+    // 빠지면 기존 사용자 도구가 죽고, 늘어나면 심사 범위가 넓어진다. 둘 다 의도적 변경일 때만.
+    expect([...ALL_SCOPES].sort()).toEqual(
+      [
+        'https://www.googleapis.com/auth/firebase',
+        'https://www.googleapis.com/auth/cloud-platform',
+        'https://www.googleapis.com/auth/admob.readonly',
+        'https://www.googleapis.com/auth/admob.monetization',
+        'https://www.googleapis.com/auth/androidpublisher',
+        'https://www.googleapis.com/auth/adwords',
+        'https://www.googleapis.com/auth/webmasters',
+        'https://www.googleapis.com/auth/analytics.edit',
+        'https://www.googleapis.com/auth/analytics.readonly',
+      ].sort(),
+    );
+  });
+
+  it('모든 도메인은 최소 1개 스코프를 갖고, 도메인 간 스코프 중복이 없다', () => {
+    const seen = new Map<string, string>();
+    for (const id of DOMAIN_IDS) {
+      expect(AUTH_DOMAINS[id].scopes.length).toBeGreaterThan(0);
+      for (const scope of AUTH_DOMAINS[id].scopes) {
+        // 한 스코프가 두 도메인에 속하면 "어느 도메인을 추가하라"는 안내가 모호해진다.
+        expect(seen.get(scope), `${scope} 이 ${seen.get(scope)} 와 ${id} 양쪽에 있음`).toBeUndefined();
+        seen.set(scope, id);
+      }
+    }
+  });
+
+  it('scopesForDomains: 미지정/빈 배열이면 전체, 서브셋이면 해당 도메인 스코프만', () => {
+    expect(scopesForDomains()).toEqual([...ALL_SCOPES]);
+    expect(scopesForDomains([])).toEqual([...ALL_SCOPES]);
+    expect(scopesForDomains(['ga4'])).toEqual([
+      'https://www.googleapis.com/auth/analytics.edit',
+      'https://www.googleapis.com/auth/analytics.readonly',
+    ]);
+    expect(scopesForDomains(['gcp', 'googleads'])).toEqual([
+      'https://www.googleapis.com/auth/cloud-platform',
+      'https://www.googleapis.com/auth/adwords',
+    ]);
+    // 중복 도메인은 dedupe
+    expect(scopesForDomains(['gsc', 'gsc'])).toEqual(['https://www.googleapis.com/auth/webmasters']);
+  });
+
+  it('domainsForScope: cloud-platform → gcp (INSUFFICIENT_SCOPE 안내에 사용)', () => {
+    expect(domainsForScope(CLOUD_PLATFORM_SCOPE)).toEqual(['gcp']);
+    expect(domainsForScope('https://www.googleapis.com/auth/analytics.readonly')).toEqual(['ga4']);
+    expect(domainsForScope('https://example.com/unknown')).toEqual([]);
+  });
+
+  it('parseDomainList: 공백 허용, dedupe, 잘못된 id 는 invalid 로 분리', () => {
+    expect(parseDomainList('ga4, googleads')).toEqual({ domains: ['ga4', 'googleads'], invalid: [] });
+    expect(parseDomainList('ga4,ga4')).toEqual({ domains: ['ga4'], invalid: [] });
+    expect(parseDomainList('ga4,nope,adwords')).toEqual({ domains: ['ga4'], invalid: ['nope', 'adwords'] });
+    expect(parseDomainList('')).toEqual({ domains: [], invalid: [] });
+  });
+
+  it('summarizeGrantedDomains: 도메인 스코프가 전부 있어야 granted, scope 미기록은 known=false', () => {
+    const full = summarizeGrantedDomains([...ALL_SCOPES].join(' '));
+    expect(full.known).toBe(true);
+    expect(full.granted).toEqual([...DOMAIN_IDS]);
+    expect(full.missing).toEqual([]);
+
+    // admob 은 스코프 2개 — 하나만 있으면 missing
+    const partial = summarizeGrantedDomains(
+      'https://www.googleapis.com/auth/admob.readonly https://www.googleapis.com/auth/webmasters',
+    );
+    expect(partial.granted).toEqual(['gsc']);
+    expect(partial.missing).toContain('admob');
+
+    expect(summarizeGrantedDomains(undefined)).toEqual({ known: false, granted: [], missing: [] });
+  });
+
+  it('isPreTrackingScope: 추적 이전 스코프만 true, GA4 및 미래 신규 스코프는 false (안전한 쪽 동결)', () => {
+    expect(isPreTrackingScope(CLOUD_PLATFORM_SCOPE)).toBe(true);
+    expect(isPreTrackingScope('https://www.googleapis.com/auth/androidpublisher')).toBe(true);
+    expect(isPreTrackingScope('https://www.googleapis.com/auth/analytics.edit')).toBe(false);
+    expect(isPreTrackingScope('https://www.googleapis.com/auth/analytics.readonly')).toBe(false);
+    // 미래에 추가될 임의의 신규 스코프는 동결 스냅샷에 없으므로 자동으로 false(미보유) —
+    // 목록 갱신을 잊어도 pre-flight 가 무력화되지 않는다는 게 핵심 불변식.
+    expect(isPreTrackingScope('https://www.googleapis.com/auth/some.future.scope')).toBe(false);
+  });
+
+  it('mergeScopeStrings: 합집합 + dedupe, undefined/빈 값 무시 (누적 scope 저장용)', () => {
+    expect(mergeScopeStrings('a b', 'b c')).toBe('a b c');
+    expect(mergeScopeStrings(undefined, 'a b')).toBe('a b');
+    expect(mergeScopeStrings('a b', undefined)).toBe('a b');
+    expect(mergeScopeStrings(undefined, undefined)).toBe('');
+    expect(mergeScopeStrings('', 'a')).toBe('a');
+    // 좁은 재로그인 시나리오: 기존 firebase 기록 + 이번 GA4 응답 → 둘 다 유지
+    const prior = 'https://www.googleapis.com/auth/firebase';
+    const now = AUTH_DOMAINS.ga4.scopes.join(' ');
+    const merged = mergeScopeStrings(prior, now).split(' ');
+    expect(merged).toContain('https://www.googleapis.com/auth/firebase');
+    expect(merged).toContain('https://www.googleapis.com/auth/analytics.edit');
+  });
+});

--- a/packages/mcp-server/src/__tests__/helpers-auth.test.ts
+++ b/packages/mcp-server/src/__tests__/helpers-auth.test.ts
@@ -6,11 +6,13 @@ const h = vi.hoisted(() => ({
   ensureFreshAccessToken: vi.fn(),
   getAuthenticatedClient: vi.fn(),
   getServiceAccountClient: vi.fn(),
+  getStoredTokens: vi.fn(),
 }));
 
 vi.mock('../auth/google-auth.js', () => ({
   ensureFreshAccessToken: h.ensureFreshAccessToken,
   getAuthenticatedClient: h.getAuthenticatedClient,
+  getStoredTokens: h.getStoredTokens,
 }));
 vi.mock('../auth/playstore-auth.js', () => ({
   getServiceAccountClient: h.getServiceAccountClient,
@@ -47,6 +49,39 @@ describe('requireAuth — 사전 갱신 + 친절한 에러', () => {
     const client = { id: 'oauth' };
     h.getAuthenticatedClient.mockReturnValue(client);
     await expect(requireAuth()).resolves.toBe(client);
+  });
+});
+
+describe('requireAuth — 스코프 pre-flight (도메인 선택형 로그인)', () => {
+  const CLOUD_PLATFORM = 'https://www.googleapis.com/auth/cloud-platform';
+  const GA4_EDIT = 'https://www.googleapis.com/auth/analytics.edit';
+  const client = { id: 'oauth' };
+
+  beforeEach(() => {
+    h.ensureFreshAccessToken.mockResolvedValue({ status: 'fresh', tokens: {}, msUntilExpiry: 999999 });
+    h.getAuthenticatedClient.mockReturnValue(client);
+  });
+
+  it('요구 스코프가 부여돼 있으면 통과', async () => {
+    h.getStoredTokens.mockReturnValue({ scope: `${CLOUD_PLATFORM} ${GA4_EDIT}` });
+    await expect(requireAuth(CLOUD_PLATFORM)).resolves.toBe(client);
+  });
+
+  it('요구 스코프 미부여면 INSUFFICIENT_SCOPE + 해당 도메인 --domains 안내로 throw', async () => {
+    h.getStoredTokens.mockReturnValue({ scope: GA4_EDIT });
+    await expect(requireAuth(CLOUD_PLATFORM)).rejects.toThrow(/INSUFFICIENT_SCOPE/);
+    await expect(requireAuth(CLOUD_PLATFORM)).rejects.toThrow(/--domains gcp/);
+  });
+
+  it('구 토큰(scope 미기록) + 추적 이전 스코프면 보유로 간주해 통과 (기존 사용자 재로그인 강제 금지)', async () => {
+    h.getStoredTokens.mockReturnValue({ scope: undefined });
+    await expect(requireAuth(CLOUD_PLATFORM)).resolves.toBe(client);
+  });
+
+  it('구 토큰(scope 미기록) + 추적 이후 스코프(GA4)면 재로그인 안내로 throw', async () => {
+    h.getStoredTokens.mockReturnValue({ scope: undefined });
+    await expect(requireAuth(GA4_EDIT)).rejects.toThrow(/INSUFFICIENT_SCOPE/);
+    await expect(requireAuth(GA4_EDIT)).rejects.toThrow(/--domains ga4/);
   });
 });
 

--- a/packages/mcp-server/src/auth/cli.ts
+++ b/packages/mcp-server/src/auth/cli.ts
@@ -9,6 +9,13 @@ import {
 } from './google-auth.js';
 import { AuthError, type AuthErrorPayload, classifyError } from './errors.js';
 import { getMcpOAuthClient } from './constants.js';
+import {
+  AUTH_DOMAINS,
+  DOMAIN_IDS,
+  parseDomainList,
+  summarizeGrantedDomains,
+  type AuthDomainId,
+} from './scopes.js';
 import { resolveLang } from '../lib/lang.js';
 
 // ko 가 원본이고 en 은 `typeof ko` 를 만족해야 한다 — 키를 빠뜨리면 컴파일이 깨진다.
@@ -20,11 +27,14 @@ const ko = {
 
   사용법:
     mimi-seed-auth                  # 로그인 (이미 있으면 자동 refresh 시도)
+    mimi-seed-auth --domains ga4,googleads   # 필요한 권한 도메인만 요청 (기존 권한 유지)
     mimi-seed-auth --refresh        # refresh_token으로 갱신만 시도 (브라우저 X)
-    mimi-seed-auth --status         # 현재 토큰 상태 출력
+    mimi-seed-auth --status         # 현재 토큰 상태 + 부여 도메인 출력
     mimi-seed-auth --logout         # 토큰 삭제
 
   옵션:
+    --domains <ids>  요청할 권한 도메인 (쉼표 구분, 미지정 시 전체).
+                     가능한 값: ${DOMAIN_IDS.join(', ')}
     --no-browser     URL 자동 오픈 안 함 (직접 복붙)
     --timeout <초>   콜백 대기 시간 (기본 600)
     --force          기존 토큰 무시하고 강제 재로그인
@@ -41,6 +51,13 @@ const ko = {
   statusRefreshed: (left: string) => `  ✅ 연결됨 — refresh_token으로 갱신 (${left})`,
   statusExpired: '  ⚠️  토큰 만료 + 자동 갱신 실패',
   statusNone: '  ❌ 연결된 계정 없음.',
+  grantedDomains: (list: string) => `     권한 도메인: ${list}`,
+  missingDomains: (list: string) =>
+    `     미부여: ${list} — mimi-seed-auth --domains <id> 로 추가 (기존 권한 유지)`,
+  domainsUnknown: '     권한 도메인: (구 토큰 — scope 기록 없음. 재로그인하면 기록됨)',
+  invalidDomains: (bad: string, valid: string) =>
+    `  ❌ 알 수 없는 도메인: ${bad}\n     가능한 값: ${valid}`,
+  domainsRequested: (list: string) => `  🎯 요청 도메인: ${list} (기존 부여 권한은 유지)`,
 
   refreshTrying: '  🔄 refresh_token으로 갱신 시도 중...',
   refreshNotNeeded: (left: string) => `  ✅ 토큰 유효 — 갱신 불필요 (${left})`,
@@ -82,11 +99,14 @@ const en: typeof ko = {
 
   Usage:
     mimi-seed-auth                  # log in (tries a silent refresh if a token exists)
+    mimi-seed-auth --domains ga4,googleads   # request only the domains you need (keeps prior grants)
     mimi-seed-auth --refresh        # only refresh with refresh_token (no browser)
-    mimi-seed-auth --status         # print the current token status
+    mimi-seed-auth --status         # print the current token status + granted domains
     mimi-seed-auth --logout         # delete the token
 
   Options:
+    --domains <ids>  Permission domains to request (comma-separated; all when omitted).
+                     Available: ${DOMAIN_IDS.join(', ')}
     --no-browser     Do not open the URL automatically (copy-paste it yourself)
     --timeout <sec>  How long to wait for the callback (default 600)
     --force          Ignore the existing token and force a re-login
@@ -103,6 +123,13 @@ const en: typeof ko = {
   statusRefreshed: (left: string) => `  ✅ Connected — refreshed with refresh_token (${left})`,
   statusExpired: '  ⚠️  Token expired + automatic refresh failed',
   statusNone: '  ❌ No connected account.',
+  grantedDomains: (list: string) => `     Granted domains: ${list}`,
+  missingDomains: (list: string) =>
+    `     Not granted: ${list} — add with mimi-seed-auth --domains <id> (prior grants are kept)`,
+  domainsUnknown: '     Granted domains: (legacy token — no scope record; re-login records it)',
+  invalidDomains: (bad: string, valid: string) =>
+    `  ❌ Unknown domain(s): ${bad}\n     Available: ${valid}`,
+  domainsRequested: (list: string) => `  🎯 Requesting domains: ${list} (prior grants are kept)`,
 
   refreshTrying: '  🔄 Trying to refresh with refresh_token...',
   refreshNotNeeded: (left: string) => `  ✅ Token still valid — no refresh needed (${left})`,
@@ -173,6 +200,17 @@ function printAuthError(p: AuthErrorPayload): void {
   if (p.cause && process.env.DEBUG) err(`     (cause: ${p.cause})`);
 }
 
+/** 도메인 선택형 로그인 이후 토큰은 전체 권한이 아닐 수 있다 — 부여 현황을 함께 출력. */
+function printGrantedDomains(): void {
+  const summary = summarizeGrantedDomains(getStoredTokens()?.scope);
+  if (!summary.known) {
+    err(M.domainsUnknown);
+    return;
+  }
+  err(M.grantedDomains(summary.granted.join(', ') || '-'));
+  if (summary.missing.length > 0) err(M.missingDomains(summary.missing.join(', ')));
+}
+
 async function cmdStatus(): Promise<number> {
   err('');
   err(M.statusTitle);
@@ -181,10 +219,12 @@ async function cmdStatus(): Promise<number> {
   switch (r.status) {
     case 'fresh':
       err(M.statusFresh(fmtRemaining(r.msUntilExpiry)));
+      printGrantedDomains();
       err('');
       return 0;
     case 'refreshed':
       err(M.statusRefreshed(fmtRemaining(r.msUntilExpiry)));
+      printGrantedDomains();
       err('');
       return 0;
     case 'expired_refresh_failed':
@@ -248,12 +288,31 @@ async function cmdLogin(): Promise<number> {
   const force = hasFlag('force');
   const timeoutSec = parseInt(flagValue('timeout') ?? '600', 10);
 
+  // --domains 파싱. 공백형(--domains ga4)과 equals형(--domains=ga4) 모두 지원하고,
+  // 플래그는 있는데 값이 없거나(--domains, --domains --force) 잘못된 id 면 조용히 전체
+  // 스코프로 폴백하지 않고 에러로 안내한다 — least-privilege 의도가 훼손되지 않도록.
+  const domainsEq = args.find((a) => a.startsWith('--domains='));
+  const domainsRaw = domainsEq ? domainsEq.slice('--domains='.length) : flagValue('domains');
+  const domainsFlagPresent = hasFlag('domains') || domainsEq !== undefined;
+  let domains: AuthDomainId[] | undefined;
+  if (domainsFlagPresent) {
+    const parsed = domainsRaw ? parseDomainList(domainsRaw) : { domains: [], invalid: [] };
+    if (parsed.invalid.length > 0 || parsed.domains.length === 0) {
+      err('');
+      err(M.invalidDomains(parsed.invalid.join(', ') || domainsRaw || '(값 없음)', DOMAIN_IDS.join(', ')));
+      err('');
+      return 1;
+    }
+    domains = parsed.domains;
+  }
+
   err('');
   err(M.loginTitle);
   err('');
 
-  // 1) 기존 토큰이 있으면 silent refresh 먼저 시도
-  if (!force) {
+  // 1) 기존 토큰이 있으면 silent refresh 먼저 시도.
+  //    --domains 는 "권한을 추가로 부여하겠다"는 명시적 의도라 이 단축 경로를 건너뛴다.
+  if (!force && !domains) {
     const existing = getStoredTokens();
     if (existing) {
       err(M.loginChecking);
@@ -285,6 +344,7 @@ async function cmdLogin(): Promise<number> {
     const { clientId, clientSecret } = await getMcpOAuthClient();
     const r = startAuth(clientId, clientSecret, {
       timeoutMs: timeoutSec * 1000,
+      domains,
     });
     url = r.url;
     wait = r.wait;
@@ -293,6 +353,10 @@ async function cmdLogin(): Promise<number> {
     printAuthError(classifyError(e, { phase: 'login' }));
     err('');
     return 1;
+  }
+
+  if (domains) {
+    err(M.domainsRequested(domains.map((d) => `${d} (${AUTH_DOMAINS[d].label})`).join(', ')));
   }
 
   // 3) 브라우저 열기 (or URL 출력)
@@ -338,6 +402,7 @@ async function cmdLogin(): Promise<number> {
   err('');
   err('');
   err(M.done);
+  printGrantedDomains();
   err('');
   err(M.nextTitle);
   err(M.nextExample1);

--- a/packages/mcp-server/src/auth/google-auth.ts
+++ b/packages/mcp-server/src/auth/google-auth.ts
@@ -7,20 +7,10 @@ import os from 'node:os';
 import { getMcpOAuthClient } from './constants.js';
 import { AuthError, classifyError, type AuthErrorPayload } from './errors.js';
 
-const SCOPES = [
-  'https://www.googleapis.com/auth/firebase',
-  'https://www.googleapis.com/auth/cloud-platform',
-  'https://www.googleapis.com/auth/admob.readonly',
-  'https://www.googleapis.com/auth/admob.monetization',
-  'https://www.googleapis.com/auth/androidpublisher',
-  'https://www.googleapis.com/auth/adwords', // Google Ads API (googleads_* tools)
-  'https://www.googleapis.com/auth/webmasters', // Search Console API (gsc_* tools, 사이트맵 제출 포함)
-  'https://www.googleapis.com/auth/analytics.edit', // GA4 Analytics Admin API (ga4_* tools — property/data stream 생성·조회)
-  // GA4 **Data API**(analyticsdata — ga4_run_report)는 analytics.edit 을 받지 않는다.
-  // Admin API 전용 스코프이기 때문. 이게 빠져 있으면 property 목록은 보이는데 리포트만
-  // 403 으로 막혀서, "API 가 꺼졌나" 로 오진하기 쉽다. (2026-07 실사고)
-  'https://www.googleapis.com/auth/analytics.readonly',
-];
+// 스코프 목록의 SSOT 는 scopes.ts (도메인 → 스코프 매핑). 여기서는 로그인 요청 조립만 한다.
+import { scopesForDomains, mergeScopeStrings, type AuthDomainId } from './scopes.js';
+
+export type { AuthDomainId } from './scopes.js';
 
 // Primary config dir. Legacy `~/.preseed` is read as a fallback during the
 // rebrand so existing auth sessions don't force a re-login; new writes go to
@@ -149,11 +139,15 @@ let activeAuthServer: http.Server | null = null;
  * 호출자가 URL을 사용자에게 전달하거나 `open()`을 직접 호출.
  * `wait` Promise: 토큰 저장 시 resolve, 타임아웃/에러 시 reject.
  * 재호출 시 기존 세션 자동 정리.
+ *
+ * `domains` 로 권한 도메인 서브셋만 요청할 수 있다 (미지정 시 전체 — 기존 동작).
+ * include_granted_scopes 덕에 재로그인은 기존 부여 스코프를 유지한 채 새 스코프만
+ * 얹는다(incremental authorization) — 토큰 응답의 scope 필드에도 누적 전체가 온다.
  */
 export function startAuth(
   clientId: string,
   clientSecret: string,
-  options: { timeoutMs?: number } = {},
+  options: { timeoutMs?: number; domains?: readonly AuthDomainId[] } = {},
 ): { url: string; wait: Promise<StoredTokens> } {
   if (activeAuthServer) {
     try { activeAuthServer.close(); } catch { /* noop */ }
@@ -162,10 +156,12 @@ export function startAuth(
 
   saveCredentials(clientId, clientSecret);
   const oauth2Client = createOAuth2Client(clientId, clientSecret);
+  const requestedScopes = scopesForDomains(options.domains);
   const authUrl = oauth2Client.generateAuthUrl({
     access_type: 'offline',
-    scope: SCOPES,
+    scope: requestedScopes,
     prompt: 'consent',
+    include_granted_scopes: true,
   });
 
   const wait = new Promise<StoredTokens>((resolve, reject) => {
@@ -221,12 +217,20 @@ export function startAuth(
           }));
           return;
         }
+        // scope 는 항상 기록한다 — 그리고 누적(monotonic)으로 저장한다.
+        //   1) include_granted_scopes 로 Google 측 grant 는 (기존 부여분 ∪ 이번 요청분)이다.
+        //   2) 응답의 tokens.scope 는 그 합집합이어야 하지만, 만약 Google 이 좁혀서 주거나
+        //      생략하면(빈 값) 여기서 기존 기록 + 이번 요청 스코프로 보정한다.
+        // 이렇게 해야 "scope 미기록 = 추적 이전 legacy 토큰" 불변식이 유지된다 — 도메인
+        // 선택형 로그인이 이를 깨서, 좁은 로그인이 legacy 로 오인돼 pre-flight 를 우회하는
+        // 것을 막는다. (기존엔 응답 scope 로 통째 덮어써서 이 두 위험에 모두 노출됐다.)
+        const priorScope = getStoredTokens()?.scope;
         const stored: StoredTokens = {
           access_token: tokens.access_token,
           refresh_token: tokens.refresh_token,
           token_type: tokens.token_type ?? 'Bearer',
           expiry_date: tokens.expiry_date ?? Date.now() + 3600_000,
-          ...(tokens.scope && { scope: tokens.scope }),
+          scope: mergeScopeStrings(priorScope, tokens.scope ?? requestedScopes.join(' ')),
         };
         saveTokens(stored);
 
@@ -279,8 +283,12 @@ export function startAuth(
  * Interactive login — opens browser, waits for callback.
  * startAuth() 래퍼 — CLI에서 사용.
  */
-export async function login(clientId: string, clientSecret: string): Promise<StoredTokens> {
-  const { url, wait } = startAuth(clientId, clientSecret);
+export async function login(
+  clientId: string,
+  clientSecret: string,
+  options: { domains?: readonly AuthDomainId[] } = {},
+): Promise<StoredTokens> {
+  const { url, wait } = startAuth(clientId, clientSecret, options);
   console.log('🔐 브라우저에서 Google 로그인 중...');
   open(url);
   return wait;

--- a/packages/mcp-server/src/auth/scopes.ts
+++ b/packages/mcp-server/src/auth/scopes.ts
@@ -1,0 +1,184 @@
+/**
+ * Google OAuth "권한 도메인" → 스코프 매핑의 SSOT.
+ *
+ * mimi-seed 는 통합 플랫폼이라 여러 구글 서비스 스코프를 다루는데, 예전엔 로그인 한 번에
+ * 전부(full-scope)를 강제로 요청했다. OAuth 앱 심사(verification)의 "Requesting Minimum
+ * Scopes" 요건과 least-privilege 원칙에 맞추기 위해, 사용자가 쓸 도메인만 골라 동의하는
+ * 선택형(incremental) 인증으로 바꿨다:
+ *
+ *   - 로그인 시 도메인 서브셋만 요청 가능 (`mimi-seed-auth --domains ga4,googleads`,
+ *     MCP `mimi_seed_auth_start` 의 `domains` 파라미터). 미지정 시 기존과 동일한 전체 요청.
+ *   - `include_granted_scopes=true` 로 요청하므로, 나중에 도메인을 추가해도 기존 부여
+ *     권한은 유지된 채 새 권한만 얹힌다 (Google incremental authorization).
+ *   - 도구 쪽은 `requireAuth(<scope>)` pre-flight 가 미부여 도메인을 결정적으로 안내한다.
+ *
+ * 도메인 경계는 "어느 도구 군이 어느 스코프를 실제 소비하는가" 기준이다. 특히
+ * cloud-platform 은 IAM API(서비스 계정 생성·키 발급)가 더 좁은 대안 스코프를 제공하지
+ * 않아서 유지하되, `gcp` 도메인으로 격리해 그 도구를 쓰는 사용자만 요청하게 한다.
+ */
+
+export interface AuthDomainDef {
+  /** 사람이 읽을 라벨 (동의 화면 아님 — CLI/도구 안내용) */
+  label: string;
+  scopes: readonly string[];
+  /** 이 도메인이 여는 도구/작업 요약 — CLI·MCP 안내 문자열에 사용 */
+  summary: string;
+}
+
+export const AUTH_DOMAINS = {
+  firebase: {
+    label: 'Firebase',
+    scopes: ['https://www.googleapis.com/auth/firebase'],
+    summary: 'firebase_* — 프로젝트/앱/설정 조회·생성 (프로젝트 신규 생성·서비스 활성화는 gcp 도 필요)',
+  },
+  gcp: {
+    label: 'Google Cloud (cloud-platform)',
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    summary:
+      'iam_* (서비스 계정·키·IAM 바인딩 — IAM API 는 이 스코프의 좁은 대안이 없음), firebase 프로젝트 생성·서비스 활성화, BigQuery OAuth fallback',
+  },
+  admob: {
+    label: 'AdMob',
+    scopes: [
+      'https://www.googleapis.com/auth/admob.readonly',
+      'https://www.googleapis.com/auth/admob.monetization',
+    ],
+    summary: 'admob_* — 수익 리포트, 앱·광고 단위 생성',
+  },
+  playstore: {
+    label: 'Play Store',
+    scopes: ['https://www.googleapis.com/auth/androidpublisher'],
+    summary: 'playstore_* — 서비스 계정 없이 OAuth 로 하는 Play Console 작업',
+  },
+  googleads: {
+    label: 'Google Ads',
+    scopes: ['https://www.googleapis.com/auth/adwords'],
+    summary: 'googleads_* — 캠페인·UAC 리포트',
+  },
+  gsc: {
+    label: 'Search Console',
+    scopes: ['https://www.googleapis.com/auth/webmasters'],
+    summary: 'gsc_* — 사이트·사이트맵·검색 성과 (사이트맵 제출 포함)',
+  },
+  ga4: {
+    label: 'Google Analytics (GA4)',
+    scopes: [
+      // Admin API(property/data stream 생성·조회) 전용.
+      'https://www.googleapis.com/auth/analytics.edit',
+      // Data API(runReport)는 analytics.edit 을 받지 않는다 — 같은 도메인이지만 별도 스코프.
+      // (ga4/tools.ts 의 GA4_DATA_SCOPE 주석, 2026-07 실사고 참고.)
+      'https://www.googleapis.com/auth/analytics.readonly',
+    ],
+    summary: 'ga4_* — property/data stream 생성·조회 + 리포트',
+  },
+} as const satisfies Record<string, AuthDomainDef>;
+
+export type AuthDomainId = keyof typeof AUTH_DOMAINS;
+
+/** z.enum 등 튜플이 필요한 자리에 쓰는 도메인 id 목록 (선언 순서 유지). */
+export const DOMAIN_IDS = Object.keys(AUTH_DOMAINS) as [AuthDomainId, ...AuthDomainId[]];
+
+export const CLOUD_PLATFORM_SCOPE = AUTH_DOMAINS.gcp.scopes[0];
+
+function dedupe(scopes: readonly string[]): string[] {
+  return [...new Set(scopes)];
+}
+
+/**
+ * 공백 구분 scope 문자열들의 합집합. tokens.json 의 scope 는 누적(monotonic)이어야 하므로
+ * 로그인/갱신 시 기존 기록 + 새 응답을 합쳐 저장하는 데 쓴다. undefined/빈 문자열은 무시.
+ */
+export function mergeScopeStrings(...parts: Array<string | undefined>): string {
+  const set = new Set<string>();
+  for (const part of parts) {
+    if (!part) continue;
+    for (const s of part.split(' ')) if (s) set.add(s);
+  }
+  return [...set].join(' ');
+}
+
+/**
+ * 전체 스코프 (도메인 선언 순서대로 평탄화).
+ * 도메인 미지정 로그인의 기본값이자, 선택형 도입 전 full-scope 목록과 동일해야 한다
+ * (auth-scopes.test.ts 가 고정한다 — 스코프가 소리 없이 빠지면 기존 사용자 도구가 죽는다).
+ */
+export const ALL_SCOPES: readonly string[] = dedupe(
+  DOMAIN_IDS.flatMap((id) => AUTH_DOMAINS[id].scopes),
+);
+
+/** 도메인 서브셋 → 요청할 스코프 목록. 미지정/빈 배열이면 전체(기존 동작). */
+export function scopesForDomains(domains?: readonly AuthDomainId[]): string[] {
+  if (!domains || domains.length === 0) return [...ALL_SCOPES];
+  return dedupe(domains.flatMap((id) => AUTH_DOMAINS[id].scopes));
+}
+
+/** 스코프 하나를 요구하는 도메인들 (INSUFFICIENT_SCOPE 안내에서 "--domains X" 를 채울 때 사용). */
+export function domainsForScope(scope: string): AuthDomainId[] {
+  return DOMAIN_IDS.filter((id) => (AUTH_DOMAINS[id].scopes as readonly string[]).includes(scope));
+}
+
+/** CLI `--domains a,b,c` 파싱. 잘못된 id 는 invalid 로 분리해 호출자가 안내한다. */
+export function parseDomainList(raw: string): { domains: AuthDomainId[]; invalid: string[] } {
+  const domains: AuthDomainId[] = [];
+  const invalid: string[] = [];
+  for (const part of raw.split(',').map((s) => s.trim()).filter(Boolean)) {
+    if ((DOMAIN_IDS as readonly string[]).includes(part)) {
+      const id = part as AuthDomainId;
+      if (!domains.includes(id)) domains.push(id);
+    } else {
+      invalid.push(part);
+    }
+  }
+  return { domains, invalid };
+}
+
+export interface GrantedDomainSummary {
+  /** tokens.json 에 scope 기록이 있는지. false 면 스코프 추적 도입 전 구 토큰. */
+  known: boolean;
+  /** 도메인의 스코프가 전부 부여된 도메인들 */
+  granted: AuthDomainId[];
+  /** 하나라도 미부여인 도메인들 */
+  missing: AuthDomainId[];
+}
+
+/** tokens.json 의 공백 구분 scope 문자열 → 도메인 단위 부여 현황. */
+export function summarizeGrantedDomains(scopeStr: string | undefined): GrantedDomainSummary {
+  if (scopeStr === undefined) return { known: false, granted: [], missing: [] };
+  const grantedScopes = new Set(scopeStr.split(' ').filter(Boolean));
+  const granted: AuthDomainId[] = [];
+  const missing: AuthDomainId[] = [];
+  for (const id of DOMAIN_IDS) {
+    if (AUTH_DOMAINS[id].scopes.every((s) => grantedScopes.has(s))) granted.push(id);
+    else missing.push(id);
+  }
+  return { known: true, granted, missing };
+}
+
+/**
+ * scope 추적 도입 시점에 **이미 존재하던** 스코프들의 **동결(frozen) 스냅샷**.
+ *
+ * 구 토큰(scope === undefined)은 추적 도입 이전의 full-scope 로그인이므로, 이 시점에
+ * 존재하던 스코프는 보유로 간주해야 한다 — 안 그러면 pre-flight 를 새로 다는 순간
+ * 멀쩡히 동작하던 기존 사용자에게 불필요한 재로그인을 강제한다.
+ *
+ * 왜 "이후 추가된 것"이 아니라 "이전에 있던 것"을 나열하는가(안전한 쪽 동결):
+ * 추적 도입 이후 추가되는 스코프(GA4 analytics.* 를 포함해 앞으로의 모든 신규 스코프)는
+ * 이 집합에 없으므로 자동으로 '추적 이후'로 분류돼, 구 토큰에서 '미보유'로 안전하게
+ * 취급된다. 반대 방향(추가된 것을 나열)으로 두면 신규 스코프를 넣는 사람이 목록 갱신을
+ * 잊는 순간 구 토큰이 그 스코프를 '보유'로 오인해 pre-flight 가 무력화된다. 이 집합은
+ * 동결이라 **새 스코프를 여기 추가할 일은 없다**(auth-scopes.test.ts 가 고정).
+ */
+const PRE_TRACKING_SCOPES: ReadonlySet<string> = new Set([
+  'https://www.googleapis.com/auth/firebase',
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/admob.readonly',
+  'https://www.googleapis.com/auth/admob.monetization',
+  'https://www.googleapis.com/auth/androidpublisher',
+  'https://www.googleapis.com/auth/adwords',
+  'https://www.googleapis.com/auth/webmasters',
+]);
+
+/** 구 토큰(scope 미기록)이 이 스코프를 보유했다고 간주해도 되는가. */
+export function isPreTrackingScope(scope: string): boolean {
+  return PRE_TRACKING_SCOPES.has(scope);
+}

--- a/packages/mcp-server/src/helpers.ts
+++ b/packages/mcp-server/src/helpers.ts
@@ -1,4 +1,5 @@
 import { getAuthenticatedClient, ensureFreshAccessToken, getStoredTokens } from './auth/google-auth.js';
+import { domainsForScope, isPreTrackingScope } from './auth/scopes.js';
 import { getServiceAccountClient, getServiceAccountJson } from './auth/playstore-auth.js';
 import { getAppStoreCredentials } from './appstore/auth.js';
 import type { AuthErrorPayload } from './auth/errors.js';
@@ -44,18 +45,30 @@ export async function requireAuth(requiredScope?: string) {
       }),
     );
   }
-  // 신규 스코프(GA4 analytics.edit 등)는 변경 전 발급된 토큰엔 없다. expiry 만 보는
-  // ensureFreshAccessToken 은 이를 못 걸러내므로(런타임 ACCESS_TOKEN_SCOPE_INSUFFICIENT),
-  // 저장된 scope 로 pre-flight 검사해 결정적인 재로그인 안내를 던진다.
-  // (scope 가 undefined 인 구 토큰은 미보유로 간주 → 재로그인 유도.)
+  // 도구가 요구하는 스코프의 pre-flight 검사. expiry 만 보는 ensureFreshAccessToken 은
+  // 스코프 미보유를 못 걸러내므로(런타임 ACCESS_TOKEN_SCOPE_INSUFFICIENT), 저장된 scope 로
+  // 결정적인 안내를 던진다. 도메인 선택형 로그인 도입 후에는 "전체 재로그인"이 아니라
+  // "--domains <해당 도메인> 으로 추가 부여(기존 권한 유지)"가 올바른 해법이다.
+  //
+  // scope 가 undefined 인 구 토큰(스코프 추적 도입 전 full-scope 로그인)은 추적 도입
+  // 이전부터 있던 스코프는 보유한 게 확실하므로 통과시킨다 — 안 그러면 pre-flight 를 새로
+  // 다는 순간 멀쩡한 기존 사용자에게 재로그인을 강제한다. 추적 이후 추가된 스코프(GA4)만
+  // 미보유 확정으로 본다.
   if (requiredScope) {
-    const granted = (getStoredTokens()?.scope ?? '').split(' ').filter(Boolean);
-    if (!granted.includes(requiredScope)) {
+    const scopeStr = getStoredTokens()?.scope;
+    const missing =
+      scopeStr === undefined
+        ? !isPreTrackingScope(requiredScope)
+        : !scopeStr.split(' ').filter(Boolean).includes(requiredScope);
+    if (missing) {
+      const domainArg = domainsForScope(requiredScope).join(',');
       throw new Error(
         formatAuthError({
           code: 'INSUFFICIENT_SCOPE',
-          message: `이 도구는 추가 권한이 필요해 (${requiredScope}). 기존 로그인에 없어서 1회 재로그인이 필요해.`,
-          hint: 'mimi-seed-auth 로 재로그인하면 새 권한이 부여돼.',
+          message: `이 도구는 추가 권한이 필요해 (${requiredScope}). 현재 로그인에 그 권한이 없어.`,
+          hint: domainArg
+            ? `mimi-seed-auth --domains ${domainArg} 로 재로그인하면 기존 권한은 유지한 채 이 권한만 추가돼.`
+            : 'mimi-seed-auth 로 재로그인하면 새 권한이 부여돼.',
           retriable: false,
           needsReauth: true,
         }),

--- a/packages/mcp-server/src/registers/auth.ts
+++ b/packages/mcp-server/src/registers/auth.ts
@@ -2,7 +2,13 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { getMcpOAuthClient } from '../auth/constants.js';
 import { classifyError } from '../auth/errors.js';
-import { startAuth, ensureFreshAccessToken, getTokensLastRefreshMs } from '../auth/google-auth.js';
+import {
+  startAuth,
+  ensureFreshAccessToken,
+  getTokensLastRefreshMs,
+  getStoredTokens,
+} from '../auth/google-auth.js';
+import { AUTH_DOMAINS, DOMAIN_IDS, summarizeGrantedDomains } from '../auth/scopes.js';
 import { listRegisteredServiceAccounts } from '../auth/playstore-auth.js';
 import { getAppStoreCredentials } from '../appstore/auth.js';
 import { loadJenkinsConfig } from '../jenkins/config.js';
@@ -284,10 +290,19 @@ export function registerAuthTools(server: McpServer) {
       'Google OAuth 로그인 링크를 발급하고 백그라운드 콜백 서버를 시작.',
       '응답에 포함된 URL을 브라우저에서 열고 승인하면 localhost:9876으로 자동 콜백 → 토큰이 ~/.mimi-seed/tokens.json에 저장됨.',
       '이후 playstore_*, firebase_*, admob_* 등 다른 MCP 도구 바로 호출 가능.',
+      'domains 로 필요한 권한 도메인만 골라 요청 가능 (미지정 시 전체). 재로그인 시 기존 부여 권한은 유지되고 새 권한만 추가됨(incremental).',
       '토큰 만료(invalid_rapt) / 재인증 필요 시 사용. 10분 내 완료해야 함.',
     ].join(' '),
-    {},
-    async () => {
+    {
+      domains: z
+        .array(z.enum(DOMAIN_IDS))
+        .optional()
+        .describe(
+          `요청할 권한 도메인 서브셋 (미지정 시 전체). 가능한 값: ${DOMAIN_IDS.join(', ')}. ` +
+            '예: ["ga4","googleads"] — 기존에 부여된 다른 도메인 권한은 유지된다.',
+        ),
+    },
+    async ({ domains }) => {
       // 설정 조회 실패를 분류된 안내로 — raw throw 는 MCP 클라이언트에 마커 문자열만 노출된다.
       let clientId: string;
       let clientSecret: string;
@@ -302,12 +317,15 @@ export function registerAuthTools(server: McpServer) {
           }],
         };
       }
-      const { url, wait } = startAuth(clientId, clientSecret);
+      const { url, wait } = startAuth(clientId, clientSecret, { domains });
       // fire-and-forget — 토큰은 콜백 서버가 자동 저장
       wait.then(
         () => { /* saved */ },
         (err: Error) => { console.error('[mimi-seed auth]', err.message); },
       );
+      const scopeLine = domains?.length
+        ? `요청 도메인: ${domains.map((d) => `${d} (${AUTH_DOMAINS[d].label})`).join(', ')} — 기존 부여 권한은 유지됨.`
+        : `요청 도메인: 전체 (${DOMAIN_IDS.join(', ')})`;
       return {
         content: [{
           type: 'text',
@@ -315,6 +333,8 @@ export function registerAuthTools(server: McpServer) {
             '🔐 Google 로그인 링크 (10분 유효):',
             '',
             url,
+            '',
+            scopeLine,
             '',
             '이 URL을 브라우저에서 열고 Google 계정으로 승인해줘.',
             '완료되면 localhost:9876으로 자동 리다이렉트되고 토큰이 저장돼.',
@@ -335,6 +355,25 @@ export function registerAuthTools(server: McpServer) {
       const refreshLine = `   마지막 갱신: ${refreshHint.label}`;
       const recommendation = refreshHint.recommendation ? `\n\n${refreshHint.recommendation}` : '';
 
+      // 도메인 선택형 로그인 이후 토큰은 전체 권한이 아닐 수 있다 — 부여 현황을 함께
+      // 보여준다. 유효/갱신된 상태에서만 쓰므로 그 두 arm 에서만 계산한다(불필요한 토큰
+      // 재조회 + 도메인 스캔 방지).
+      const domainStatusBlock = (): string => {
+        const summary = summarizeGrantedDomains(getStoredTokens()?.scope);
+        const domainLines: string[] = [];
+        if (!summary.known) {
+          domainLines.push('   권한 도메인: (구 토큰 — scope 기록 없음. 재로그인하면 기록됨)');
+        } else {
+          domainLines.push(`   권한 도메인: ${summary.granted.join(', ') || '(없음)'}`);
+          if (summary.missing.length > 0) {
+            domainLines.push(
+              `   미부여: ${summary.missing.join(', ')} → mimi_seed_auth_start(domains=[...]) 로 추가 (기존 권한 유지)`,
+            );
+          }
+        }
+        return `\n${domainLines.join('\n')}`;
+      };
+
       switch (r.status) {
         case 'unauthenticated':
           return {
@@ -351,7 +390,7 @@ export function registerAuthTools(server: McpServer) {
           return {
             content: [{
               type: 'text',
-              text: `✅ 인증 유효 (${min}분 남음).\n${refreshLine}${recommendation}`,
+              text: `✅ 인증 유효 (${min}분 남음).\n${refreshLine}${domainStatusBlock()}${recommendation}`,
             }],
           };
         }
@@ -360,7 +399,7 @@ export function registerAuthTools(server: McpServer) {
           return {
             content: [{
               type: 'text',
-              text: `✅ 토큰 만료 → refresh_token으로 자동 갱신 완료 (${min}분 남음).\n${refreshLine}${recommendation}`,
+              text: `✅ 토큰 만료 → refresh_token으로 자동 갱신 완료 (${min}분 남음).\n${refreshLine}${domainStatusBlock()}${recommendation}`,
             }],
           };
         }

--- a/packages/mcp-server/src/registers/firebase.ts
+++ b/packages/mcp-server/src/registers/firebase.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import * as firebaseRaw from '../firebase/tools.js';
 import { requireAuth } from '../helpers.js';
+import { CLOUD_PLATFORM_SCOPE } from '../auth/scopes.js';
 import { friendlyGoogleError } from '../lib/google-errors.js';
 
 // 모든 firebase tools 호출을 친절 에러로 감싸는 프록시 — 17개 핸들러에 개별
@@ -70,7 +71,8 @@ export function registerFirebaseTools(server: McpServer) {
         .describe("조직/폴더 소속이 필요한 계정일 때만: 'organizations/<id>' 또는 'folders/<id>'. 생략 시 계정 기본 정책대로 생성"),
     },
     async ({ projectId, displayName, parent }) => {
-      const auth = await requireAuth();
+      // 프로젝트 생성은 Cloud Resource Manager 라 firebase 스코프만으로는 안 된다.
+      const auth = await requireAuth(CLOUD_PLATFORM_SCOPE);
       const project = await firebase.createProject(auth, projectId, displayName, { parent });
       return {
         content: [
@@ -262,7 +264,8 @@ export function registerFirebaseTools(server: McpServer) {
       serviceId: z.string().describe('서비스 ID (예: firestore.googleapis.com)'),
     },
     async ({ projectId, serviceId }) => {
-      const auth = await requireAuth();
+      // Service Usage API — firebase 스코프가 아니라 cloud-platform 을 요구한다.
+      const auth = await requireAuth(CLOUD_PLATFORM_SCOPE);
       const result = await firebase.enableService(auth, projectId, serviceId);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     },
@@ -273,7 +276,7 @@ export function registerFirebaseTools(server: McpServer) {
     'Firebase 기본 서비스 일괄 활성화 (Firestore, Auth, Storage, FCM 등)',
     { projectId: z.string().describe('프로젝트 ID') },
     async ({ projectId }) => {
-      const auth = await requireAuth();
+      const auth = await requireAuth(CLOUD_PLATFORM_SCOPE);
       const results = await firebase.enableCommonServices(auth, projectId);
       return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
     },
@@ -284,7 +287,7 @@ export function registerFirebaseTools(server: McpServer) {
     '프로젝트에서 활성화된 GCP 서비스 목록',
     { projectId: z.string().describe('프로젝트 ID') },
     async ({ projectId }) => {
-      const auth = await requireAuth();
+      const auth = await requireAuth(CLOUD_PLATFORM_SCOPE);
       const services = await firebase.listEnabledServices(auth, projectId);
       return { content: [{ type: 'text', text: JSON.stringify(services, null, 2) }] };
     },

--- a/packages/mcp-server/src/registers/iam.ts
+++ b/packages/mcp-server/src/registers/iam.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import * as iam from '../iam/tools.js';
 import { requireAuth } from '../helpers.js';
+import { CLOUD_PLATFORM_SCOPE } from '../auth/scopes.js';
 
 export function registerIamTools(server: McpServer) {
   server.tool(
@@ -11,7 +12,7 @@ export function registerIamTools(server: McpServer) {
       projectId: z.string().describe('Google Cloud 프로젝트 ID'),
     },
     async ({ projectId }) => {
-      const auth = await requireAuth();
+      const auth = await requireAuth(CLOUD_PLATFORM_SCOPE);
       const accounts = await iam.listServiceAccounts(auth, projectId);
       return { content: [{ type: 'text', text: JSON.stringify(accounts, null, 2) }] };
     },
@@ -29,7 +30,7 @@ export function registerIamTools(server: McpServer) {
       displayName: z.string().describe('사람이 읽을 표시 이름 (예: "onesub Play verifier")'),
     },
     async ({ projectId, accountId, displayName }) => {
-      const auth = await requireAuth();
+      const auth = await requireAuth(CLOUD_PLATFORM_SCOPE);
       const account = await iam.createServiceAccount(auth, projectId, accountId, displayName);
       return {
         content: [
@@ -59,7 +60,7 @@ export function registerIamTools(server: McpServer) {
       serviceAccount: z.string().describe('서비스 계정 이메일'),
     },
     async ({ serviceAccount }) => {
-      const auth = await requireAuth();
+      const auth = await requireAuth(CLOUD_PLATFORM_SCOPE);
       const keys = await iam.listServiceAccountKeys(auth, serviceAccount);
       return { content: [{ type: 'text', text: JSON.stringify(keys, null, 2) }] };
     },
@@ -75,7 +76,7 @@ export function registerIamTools(server: McpServer) {
       serviceAccount: z.string().describe('서비스 계정 이메일'),
     },
     async ({ serviceAccount }) => {
-      const auth = await requireAuth();
+      const auth = await requireAuth(CLOUD_PLATFORM_SCOPE);
       const key = await iam.createServiceAccountKey(auth, serviceAccount);
       return {
         content: [
@@ -119,7 +120,7 @@ export function registerIamTools(server: McpServer) {
       role: z.string().describe('IAM 역할 (예: roles/iam.serviceAccountTokenCreator)'),
     },
     async ({ projectId, member, role }) => {
-      const auth = await requireAuth();
+      const auth = await requireAuth(CLOUD_PLATFORM_SCOPE);
       const result = await iam.addProjectIamPolicyBinding(auth, projectId, member, role);
       return {
         content: [

--- a/plugins/mimi-seed/.codex-plugin/plugin.json
+++ b/plugins/mimi-seed/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Codex에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/plugins/mimi-seed/docs/agent-guide.md
+++ b/plugins/mimi-seed/docs/agent-guide.md
@@ -80,13 +80,13 @@ every credential, which also tells them where to obtain each token
 
 | Service | Fix |
 |---------|-----|
-| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login` |
+| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login`. Both accept a **domain subset** (`domains=["ga4","googleads"]` / `--domains ga4,googleads`) — request only what the task needs; re-auth keeps prior grants (incremental). Omit for all domains |
 | App Store Connect | `mimi-seed auth appstore` → verify with `appstore_verify_credentials` |
 | Play service account | `mimi-seed auth playstore`, or register per-package with `playstore_register_service_account`. **Optional** — the OAuth token carries `androidpublisher`, so this is only needed for headless/CI |
 | BigQuery | `mimi-seed auth bigquery` (optional — OAuth works too) |
 | Jenkins | `mimi-seed auth jenkins` (probes the server before saving) |
 | GitHub / GitLab CI | `mimi-seed auth ci` |
-| Google Ads | `mimi-seed auth googleads` — needs the `adwords` OAuth scope; an old token may need `mimi-seed auth login --force` |
+| Google Ads | `mimi-seed auth googleads` — needs the `adwords` OAuth scope; an old token may need `mimi-seed auth login --domains googleads` (adds the grant, keeps the rest) |
 | Facebook / Instagram / Threads | `mimi-seed auth facebook` / `mimi-seed auth instagram` / `mimi-seed auth threads` |
 
 `mimi-seed auth meta` opens the combined social setup entry point when the user wants to review or reconnect

--- a/plugins/mimi-seed/docs/domain/auth-credentials.md
+++ b/plugins/mimi-seed/docs/domain/auth-credentials.md
@@ -52,6 +52,24 @@ All under `~/.mimi-seed/` (legacy `~/.preseed/` is still read as a fallback):
   metadata research, `PEXELS_API_KEY` for stock search, and `OPENAI_API_KEY` for generated images. Rendering
   itself is local and needs FFmpeg on `PATH` or `MIMI_SEED_FFMPEG_PATH`.
 
+## Domain-selective (incremental) Google OAuth
+
+The Google OAuth login no longer forces the full scope list. The SSOT for the **auth-domain → scope**
+mapping is `mcp-server/src/auth/scopes.ts` (`AUTH_DOMAINS`: `firebase`, `gcp`, `admob`, `playstore`,
+`googleads`, `gsc`, `ga4`) — least-privilege consent for the OAuth verification "minimum scopes" requirement:
+
+- `mimi-seed-auth --domains ga4,googleads` (CLI) and `mimi_seed_auth_start(domains=[…])` (MCP) request only
+  the selected domains' scopes; omitting the option requests everything (old behavior).
+- Requests are sent with `include_granted_scopes=true`, so a re-login **adds** the new scopes on top of the
+  existing grant instead of replacing it. `tokens.json` stores the cumulative granted `scope` string.
+- `requireAuth(<scope>)` in `helpers.ts` pre-flights a tool's required scope against the stored grant and, on
+  a miss, tells the user exactly which `--domains <id>` to add. Legacy tokens with no `scope` field are
+  assumed to hold every pre-tracking scope (only the GA4 scopes postdate scope tracking) so existing users
+  are not forced into a pointless re-login.
+- `cloud-platform` is isolated in the `gcp` domain because the IAM API offers no narrower scope; the
+  `firebase` domain alone cannot create projects (Cloud Resource Manager) or enable services (Service
+  Usage) — those tools pre-flight `cloud-platform` and point at `gcp`.
+
 ## Setup sub-CLIs
 
 Each setup flow is both a `bin` in `mcp-server/package.json` and an entry in the `SUBCOMMANDS` map


### PR DESCRIPTION
## Why

Google OAuth verification (project `preseed-491916`) flagged our consent flow for requesting broad scopes without evidenced least-privilege. The login was all-or-nothing: every user had to consent to all 9 scopes (`cloud-platform`, `adwords`, `analytics.*`, …) even to use just Firebase. This makes it impossible to answer the reviewer's "why can't narrower permissions be used?" / "is this a least-privilege integration platform?" honestly.

This PR makes consent **per-domain and incremental**, so mimi-seed can truthfully present itself as an integration platform offering granular, opt-in permissions.

## What

- **New SSOT `auth/scopes.ts`** — `AUTH_DOMAINS` maps 7 permission domains (`firebase`, `gcp`, `admob`, `playstore`, `googleads`, `gsc`, `ga4`) → scopes. `cloud-platform` is isolated in `gcp` because the IAM API accepts no narrower scope. A test pins the full-scope union so scopes can't silently drift.
- **Incremental login** — `startAuth`/`login` accept a domain subset (omit = all, fully backward compatible) and request `include_granted_scopes=true`, so re-login **adds** scopes on top of the existing grant instead of replacing it.
- **Cumulative scope recording** — `tokens.json` `scope` is now always written and stored as the union of prior + returned|requested scopes, so a narrow re-login can never shrink or blank the recorded grant.
- **Generalized pre-flight** — `requireAuth(scope)` on a miss names the exact `--domains <id>` to add; legacy tokens are matched against a frozen pre-tracking snapshot (new scopes default to the safe not-held side). Applied to `iam_*` and `firebase` create/enable — the real `cloud-platform` consumers.
- **Three entry points** — `mimi_seed_auth_start(domains=[…])`, `mimi-seed-auth --domains ga4,googleads`, and granted/missing-domain status output. The CLI errors on a missing `--domains` value instead of silently full-scoping.

## Adversarial review

Ran `/code-review high` (3 correctness + 3 cleanup + altitude + conventions angles, independently verified). Fixed before this PR:

1. **Scope clobber (primary)** — the fresh-login callback overwrote `tokens.json.scope` from the response with no merge and only conditionally; a narrow login whose response omits `scope` produced a token indistinguishable from a legacy one, which then wrongly passed the `cloud-platform` pre-flight. Fixed with the cumulative `mergeScopeStrings` store.
2. **Silent full-scope fallback** — `--domains=ga4` / `--domains --force` fell through to a full-scope login. Now errors.
3. **Pre-tracking set rotted on the unsafe side** — flipped to a frozen `PRE_TRACKING_SCOPES` snapshot so future scopes default to not-held.
4. Dead `domainBlock` work + an unreachable alias cleaned up.

**Known follow-ups (out of scope):** the BigQuery OAuth *fallback* still lacks a `cloud-platform` pre-flight, so a narrow login excluding `gcp` gives it a raw 403 instead of `--domains gcp` guidance (BigQuery's primary path is a service account with its own auth CLI). `summarizeGrantedDomains` labels a partially-granted domain as fully missing (cosmetic; corrective advice is idempotent).

## Verify

`npm run build && npm test` in both packages — mcp-server 260 pass, cli 134 pass. `plugin:check` clean at 0.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)