### PR TITLE
fix: threads publish via /me endpoints — v0.12.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed",
   "displayName": "Mimi Seed",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Claude Code에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Codex에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/docs/domain/pitfalls.md
+++ b/docs/domain/pitfalls.md
@@ -155,3 +155,15 @@ edit. Values from those files eventually reach FFmpeg arguments and filters, so 
 a security boundary. Every read goes through the Zod schemas in `video/schemas.ts`; project, asset manifest, and
 timeline also carry the same `projectId` to reject stale cross-project state. Keep JSON writes atomic and validate
 again at the file boundary before building a render command.
+
+## 17. Meta carousel publishing can outlive the default MCP timeout
+
+Threads publishing should use the token-scoped `/me/threads` and `/me/threads_publish` endpoints. A saved numeric
+user ID is still useful for account reads, but using it for writes can return Meta `code 24/4279009` even when the
+token and account are valid.
+
+Instagram and Threads carousels also create and poll every child container before polling the parent. That can
+legitimately exceed the MCP SDK's 60-second default request timeout. Callers that own the MCP client should set a
+timeout longer than the server's total media-processing budget. If the client still times out, the publish result
+is unknown: inspect the account's latest media before retrying, because the provider may have completed the post
+after the client stopped waiting.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed-sdk",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Monorepo root — the SDK version (SSOT for both packages and client plugin manifests) plus bootstrap scripts. The publishable packages live in packages/. This is NOT an npm workspace: each package installs independently.",
   "type": "module",
   "engines": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Mimi Seed CLI — Claude Code와 Codex에서 앱 출시 운영을 관리합니다.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Mimi Seed MCP server — Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/__tests__/threads-api.test.ts
+++ b/packages/mcp-server/src/__tests__/threads-api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { postCarousel, refreshAccessToken } from '../threads/api.js';
+import { postCarousel, postText, refreshAccessToken } from '../threads/api.js';
 
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), {
   status,
@@ -59,8 +59,30 @@ describe('Threads API', () => {
     }));
     const parentStatusIndex = calls.findIndex(({ url, method }) =>
       method === 'GET' && url.includes('/carousel-1?'));
-    const publishIndex = calls.findIndex(({ url }) => url.includes('/user-1/threads_publish'));
+    const publishIndex = calls.findIndex(({ url }) => url.includes('/me/threads_publish'));
     expect(parentStatusIndex).toBeGreaterThan(-1);
     expect(publishIndex).toBeGreaterThan(parentStatusIndex);
+
+    const createCalls = calls.filter(({ method, url }) =>
+      method === 'POST' && new URL(url).pathname === '/v1.0/me/threads');
+    expect(createCalls).toHaveLength(3);
+    expect(calls.every(({ url }) => !url.includes('/user-1/threads'))).toBe(true);
+  });
+
+  it('텍스트 게시도 저장된 숫자 ID 대신 공식 /me 경로를 사용한다', async () => {
+    const responses = [
+      { id: 'container-1' },
+      { id: 'published-1' },
+      { permalink: 'https://www.threads.net/@example/post/1' },
+    ];
+    const fetchMock = vi.fn(async () => json(responses.shift()));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postText({ accessToken: 'THQVJ_TOKEN', userId: 'stale-user-id' }, 'hello');
+
+    const paths = fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname);
+    expect(paths[0]).toBe('/v1.0/me/threads');
+    expect(paths[1]).toBe('/v1.0/me/threads_publish');
+    expect(paths).not.toContain('/v1.0/stale-user-id/threads');
   });
 });

--- a/packages/mcp-server/src/threads/api.ts
+++ b/packages/mcp-server/src/threads/api.ts
@@ -3,7 +3,7 @@ import { metaApiError } from '../lib/meta-auth.js';
 
 // Threads Graph API. Instagram 과 달리 base 가 하나뿐이라 토큰 prefix 분기가 없다.
 //   graph.threads.net/v1.0
-// 게시 흐름은 인스타와 같은 2단계: container 생성(/threads) → publish(/threads_publish).
+// 게시 흐름은 인스타와 같은 2단계: container 생성(/me/threads) → publish(/me/threads_publish).
 // 차이: (1) 텍스트 전용 게시가 1급 시민(media_type=TEXT), (2) 미디어 컨테이너는 처리 시간이
 //       필요해 publish 전에 status 를 폴링해야 한다, (3) 캐러셀 최대 20장(인스타는 10장).
 const BASE = 'https://graph.threads.net/v1.0';
@@ -158,7 +158,7 @@ async function waitForContainer(cfg: ThreadsConfig, containerId: string): Promis
 async function publish(cfg: ThreadsConfig, creationId: string): Promise<PublishResult> {
   const published = await thFetch<{ id: string }>(
     cfg.accessToken,
-    `/${cfg.userId}/threads_publish`,
+    '/me/threads_publish',
     { creation_id: creationId, access_token: cfg.accessToken },
     'POST',
   );
@@ -180,7 +180,7 @@ export async function postText(
 
   const container = await thFetch<{ id: string }>(
     cfg.accessToken,
-    `/${cfg.userId}/threads`,
+    '/me/threads',
     params,
     'POST',
   );
@@ -203,7 +203,7 @@ export async function postCarousel(
   for (const url of imageUrls) {
     const child = await thFetch<{ id: string }>(
       cfg.accessToken,
-      `/${cfg.userId}/threads`,
+      '/me/threads',
       { media_type: 'IMAGE', image_url: url, is_carousel_item: 'true', access_token: cfg.accessToken },
       'POST',
     );
@@ -216,7 +216,7 @@ export async function postCarousel(
   // Step 2: carousel container 생성
   const carousel = await thFetch<{ id: string }>(
     cfg.accessToken,
-    `/${cfg.userId}/threads`,
+    '/me/threads',
     { media_type: 'CAROUSEL', children: childIds.join(','), text, access_token: cfg.accessToken },
     'POST',
   );

--- a/plugins/mimi-seed/.codex-plugin/plugin.json
+++ b/plugins/mimi-seed/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Codex에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/plugins/mimi-seed/docs/domain/pitfalls.md
+++ b/plugins/mimi-seed/docs/domain/pitfalls.md
@@ -155,3 +155,15 @@ edit. Values from those files eventually reach FFmpeg arguments and filters, so 
 a security boundary. Every read goes through the Zod schemas in `video/schemas.ts`; project, asset manifest, and
 timeline also carry the same `projectId` to reject stale cross-project state. Keep JSON writes atomic and validate
 again at the file boundary before building a render command.
+
+## 17. Meta carousel publishing can outlive the default MCP timeout
+
+Threads publishing should use the token-scoped `/me/threads` and `/me/threads_publish` endpoints. A saved numeric
+user ID is still useful for account reads, but using it for writes can return Meta `code 24/4279009` even when the
+token and account are valid.
+
+Instagram and Threads carousels also create and poll every child container before polling the parent. That can
+legitimately exceed the MCP SDK's 60-second default request timeout. Callers that own the MCP client should set a
+timeout longer than the server's total media-processing budget. If the client still times out, the publish result
+is unknown: inspect the account's latest media before retrying, because the provider may have completed the post
+after the client stopped waiting.


### PR DESCRIPTION
## Why

Threads container-create and publish targeted `/${cfg.userId}/threads` and `/${cfg.userId}/threads_publish`. Writing against a saved numeric user ID can return Meta `code 24/4279009` even when the token and account are valid — the token-scoped `/me/threads` and `/me/threads_publish` endpoints are the correct write path.

## What

- `postText`, `publish`, and `postCarousel` (every child + parent create) now use `/me/...`.
- `cfg.userId` is kept — it's still used for account reads (`getAccount`) and setup, which is correct.
- Tests assert the `/me` path is used and the stale user ID never appears; adds a `postText` case.
- `pitfalls.md` §17 documents the fix plus the related carousel/MCP-timeout gotcha (child containers are polled before the parent, which can exceed the SDK's 60s default timeout; on client timeout the publish result is unknown — inspect latest media before retrying).

## Verify

`npm run build && npm test` in mcp-server — 260 pass. `plugin:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)