### PR TITLE
feat: add YouTube publishing tools

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed",
   "displayName": "Mimi Seed",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Claude Code에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Codex에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/README.ko.md
+++ b/README.ko.md
@@ -392,7 +392,7 @@ SDK에 기여한다면 **도메인 온톨로지** [`docs/domain/`](docs/domain/)
 | **Android 서명** | 3 | `android_signing_setup` · `android_generate_keystore` · `jenkins_upload_playstore_sa` |
 | **인증** | 4 | `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
 | **AI** | 2 | `generate_release_notes_from_commits` · `generate_review_reply` |
-| **영상 제작** | 11 | `video_plan_from_story` · `video_research_youtube` · `video_synthesize_research` · `video_generate_image` · `video_render` |
+| **영상 제작** | 14 | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_render` |
 
 전체 카탈로그 → [`docs/domain/tool-catalog.md`](docs/domain/tool-catalog.md) · 소스 → [packages/mcp-server](packages/mcp-server)
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ full tool catalog, the auth/credential model, and known pitfalls — start at
 | **Android signing** | 3 | `android_signing_setup` · `android_generate_keystore` · `jenkins_upload_playstore_sa` |
 | **Auth** | 4 | `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
 | **AI** | 2 | `generate_release_notes_from_commits` · `generate_review_reply` |
-| **Video production** | 11 | `video_plan_from_story` · `video_research_youtube` · `video_synthesize_research` · `video_generate_image` · `video_render` |
+| **Video production** | 14 | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_render` |
 
 Full catalog → [`docs/domain/tool-catalog.md`](docs/domain/tool-catalog.md) · source → [packages/mcp-server](packages/mcp-server)
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -57,6 +57,7 @@ tools directly — but the *call order* and *safety rules* below still apply.
 | CI (GitHub/GitLab) | `select:ci_save_config,ci_list_workflows,ci_trigger_build,ci_get_build_status,ci_list_recent_builds` |
 | Service account end-to-end | `select:iam_create_service_account,iam_create_key,iam_add_iam_policy_binding,playstore_register_service_account,playstore_verify_service_account` |
 | Story → researched video | `select:video_plan_from_story,video_research_youtube,video_search_stock_assets,video_synthesize_research,video_download_stock_assets,video_generate_image,video_add_local_asset,video_build_timeline,video_render,video_job_status,video_validate` |
+| YouTube upload / publish | `select:youtube_upload_video,youtube_get_video_status,youtube_update_video_privacy,mimi_seed_auth_start` |
 
 ---
 
@@ -80,7 +81,7 @@ every credential, which also tells them where to obtain each token
 
 | Service | Fix |
 |---------|-----|
-| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login`. Both accept a **domain subset** (`domains=["ga4","googleads"]` / `--domains ga4,googleads`) — request only what the task needs; re-auth keeps prior grants (incremental). Omit for all domains |
+| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery/YouTube) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login`. Both accept a **domain subset** (`domains=["youtube"]` / `--domains youtube`) — request only what the task needs; re-auth keeps prior grants (incremental). Omit for all domains |
 | App Store Connect | `mimi-seed auth appstore` → verify with `appstore_verify_credentials` |
 | Play service account | `mimi-seed auth playstore`, or register per-package with `playstore_register_service_account`. **Optional** — the OAuth token carries `androidpublisher`, so this is only needed for headless/CI |
 | BigQuery | `mimi-seed auth bigquery` (optional — OAuth works too) |
@@ -153,7 +154,7 @@ per-domain inventory is [`docs/domain/tool-catalog.md`](domain/tool-catalog.md).
 | **Facebook / Instagram / Threads** | `facebook_post_photo` · `instagram_post_carousel` · `threads_post` · `threads_refresh_token` |
 | **Checks** | `playstore_check_submission_risks` · `appstore_check_submission_risks` · `screenshot_validate` · `release_status` |
 | **AI / Auth** | `generate_release_notes_from_commits` · `generate_review_reply` · `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
-| **Video production** | `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
+| **Video production** | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
 
 ---
 

--- a/docs/credentials.ko.md
+++ b/docs/credentials.ko.md
@@ -47,7 +47,7 @@ Cloud IAM · BigQuery 가 모두 같은 OAuth 토큰을 탄다. 여기서 시작
 
 ## Google OAuth
 
-**열리는 것:** `firebase_*`, `admob_*`, `playstore_*`, `googleads_*`, `gsc_*`, `ga4_*`, `iam_*`, `bigquery_*`
+**열리는 것:** `firebase_*`, `admob_*`, `playstore_*`, `googleads_*`, `gsc_*`, `ga4_*`, `iam_*`, `bigquery_*`, `youtube_*`
 
 **먼저 필요한 것:** Google 계정. 그게 전부다.
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -47,7 +47,7 @@ and BigQuery all ride on the same OAuth token. Start there.
 
 ## Google OAuth
 
-**Unlocks:** `firebase_*`, `admob_*`, `playstore_*`, `googleads_*`, `gsc_*`, `ga4_*`, `iam_*`, `bigquery_*`
+**Unlocks:** `firebase_*`, `admob_*`, `playstore_*`, `googleads_*`, `gsc_*`, `ga4_*`, `iam_*`, `bigquery_*`, `youtube_*`
 
 **You need first:** a Google account. That's all.
 

--- a/docs/domain/auth-credentials.md
+++ b/docs/domain/auth-credentials.md
@@ -56,10 +56,12 @@ All under `~/.mimi-seed/` (legacy `~/.preseed/` is still read as a fallback):
 
 The Google OAuth login no longer forces the full scope list. The SSOT for the **auth-domain → scope**
 mapping is `mcp-server/src/auth/scopes.ts` (`AUTH_DOMAINS`: `firebase`, `gcp`, `admob`, `playstore`,
-`googleads`, `gsc`, `ga4`) — least-privilege consent for the OAuth verification "minimum scopes" requirement:
+`googleads`, `gsc`, `ga4`, `youtube`) — least-privilege consent for the OAuth verification "minimum scopes" requirement:
 
 - `mimi-seed-auth --domains ga4,googleads` (CLI) and `mimi_seed_auth_start(domains=[…])` (MCP) request only
   the selected domains' scopes; omitting the option requests everything (old behavior).
+- The `youtube` domain unlocks video upload, processing/status reads, and privacy changes without introducing
+  a second credential store.
 - Requests are sent with `include_granted_scopes=true`, so a re-login **adds** the new scopes on top of the
   existing grant instead of replacing it. `tokens.json` stores the cumulative granted `scope` string.
 - `requireAuth(<scope>)` in `helpers.ts` pre-flights a tool's required scope against the stored grant and, on

--- a/docs/domain/external-apis.md
+++ b/docs/domain/external-apis.md
@@ -19,6 +19,7 @@
 | GA4 | GA4 Admin + Data APIs | `googleapis` |
 | Search Console | Search Console API | `googleapis` |
 | Google Ads | Google Ads reporting | `googleapis` / REST per `googleads_save_config` |
+| YouTube publishing | YouTube Data API v3 (upload, processing/status, privacy) | `googleapis` + local file streams |
 | App Store Connect | ASC REST API | `fetch` + **`jose`** JWT (ES256, minted per request) |
 | Facebook / Instagram / Threads | Meta Graph APIs | `fetch`; shared expiry/error recovery in `lib/meta-auth.ts` |
 | AI tools | Anthropic Messages API | `@anthropic-ai/sdk` (needs `ANTHROPIC_API_KEY`) |

--- a/docs/domain/pitfalls.md
+++ b/docs/domain/pitfalls.md
@@ -167,3 +167,8 @@ legitimately exceed the MCP SDK's 60-second default request timeout. Callers tha
 timeout longer than the server's total media-processing budget. If the client still times out, the publish result
 is unknown: inspect the account's latest media before retrying, because the provider may have completed the post
 after the client stopped waiting.
+
+The same unknown-result rule applies to `youtube_upload_video`. The upload request streams the local file directly
+and can outlive the MCP client's timeout even though YouTube later finishes creating the video. Never automatically
+retry a timed-out upload. Check YouTube Studio for a matching recent title/file first; if the call returned a
+`videoId`, use `youtube_get_video_status` to reconcile processing and privacy state.

--- a/docs/domain/tool-catalog.md
+++ b/docs/domain/tool-catalog.md
@@ -1,4 +1,4 @@
-# Tool catalog — 174 tools across 19 domains
+# Tool catalog — 177 tools across 19 domains
 
 > The MCP server's "entities". One row per domain → register file → tools, with **W** (write) and **D**
 > (destructive / near-irreversible) markers. Everything unmarked is read-only.
@@ -29,8 +29,8 @@
 | Auth | `registers/auth.ts` | 4 |
 | Android signing | `registers/android.ts` | 3 |
 | AI | `registers/ai.ts` | 2 |
-| Video production | `registers/video.ts` | 11 |
-| **Total** | **19 modules** | **174** |
+| Video production | `registers/video.ts` | 14 |
+| **Total** | **19 modules** | **177** |
 
 ## Google Play — `registers/playstore.ts` (29) · impl `playstore/tools.ts`
 
@@ -102,10 +102,12 @@
 | Auth (`auth.ts`) | `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
 | AI (`ai.ts`) — needs `ANTHROPIC_API_KEY` | `generate_release_notes_from_commits` · `generate_review_reply` |
 
-## Video production — `registers/video.ts` (11) · impl `video/*.ts`
+## Video production — `registers/video.ts` (14) · impl `video/*.ts`
 
-- Research/read: `video_research_youtube` (metadata/reference-only) · `video_search_stock_assets` ·
-  `video_job_status` · `video_validate`
+- Research/read: `youtube_get_video_status` · `video_research_youtube` (metadata/reference-only) ·
+  `video_search_stock_assets` · `video_job_status` · `video_validate`
+- **W** `youtube_upload_video` (기본 private, public/unlisted는 명시 확인 필수) ·
+  `youtube_update_video_privacy` (public/unlisted는 명시 확인 필수)
 - **W** `video_plan_from_story` (Anthropic + local project) · `video_synthesize_research` (metadata/user notes →
   bounded brief) · `video_download_stock_assets` (Pexels, preview then
   confirm) · `video_generate_image` (OpenAI, preview then confirm) · `video_add_local_asset` ·

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed-sdk",
   "private": true,
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Monorepo root — the SDK version (SSOT for both packages and client plugin manifests) plus bootstrap scripts. The publishable packages live in packages/. This is NOT an npm workspace: each package installs independently.",
   "type": "module",
   "engines": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Mimi Seed CLI — Claude Code와 Codex에서 앱 출시 운영을 관리합니다.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -96,7 +96,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 | Android 서명 | 3 | `android_signing_setup` / `android_generate_keystore` / `jenkins_upload_playstore_sa` |
 | 인증 | 4 | `mimi_seed_status` / `mimi_seed_auth_start` / `mimi_seed_auth_status` / `mimi_seed_remote_sync_credentials` |
 | AI (Claude) | 2 | `generate_release_notes_from_commits` / `generate_review_reply` |
-| 영상 제작 | 11 | `video_plan_from_story` / `video_research_youtube` / `video_synthesize_research` / `video_generate_image` / `video_render` |
+| 영상 제작·YouTube | 14 | `youtube_upload_video` / `youtube_get_video_status` / `youtube_update_video_privacy` / `video_plan_from_story` / `video_render` |
 
 > 인앱 결제(IAP·구독) 도구는 위 Play Store·App Store 카운트에 포함됩니다 — `appstore_create_inapp_purchase` · `appstore_update_product_review_note` · `appstore_upload_product_review_screenshot` 등.
 > 전체 카탈로그(항상 최신): [`docs/domain/tool-catalog.md`](../../docs/domain/tool-catalog.md)

--- a/packages/mcp-server/assets/agent-guide.md
+++ b/packages/mcp-server/assets/agent-guide.md
@@ -57,6 +57,7 @@ tools directly — but the *call order* and *safety rules* below still apply.
 | CI (GitHub/GitLab) | `select:ci_save_config,ci_list_workflows,ci_trigger_build,ci_get_build_status,ci_list_recent_builds` |
 | Service account end-to-end | `select:iam_create_service_account,iam_create_key,iam_add_iam_policy_binding,playstore_register_service_account,playstore_verify_service_account` |
 | Story → researched video | `select:video_plan_from_story,video_research_youtube,video_search_stock_assets,video_synthesize_research,video_download_stock_assets,video_generate_image,video_add_local_asset,video_build_timeline,video_render,video_job_status,video_validate` |
+| YouTube upload / publish | `select:youtube_upload_video,youtube_get_video_status,youtube_update_video_privacy,mimi_seed_auth_start` |
 
 ---
 
@@ -80,7 +81,7 @@ every credential, which also tells them where to obtain each token
 
 | Service | Fix |
 |---------|-----|
-| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login`. Both accept a **domain subset** (`domains=["ga4","googleads"]` / `--domains ga4,googleads`) — request only what the task needs; re-auth keeps prior grants (incremental). Omit for all domains |
+| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery/YouTube) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login`. Both accept a **domain subset** (`domains=["youtube"]` / `--domains youtube`) — request only what the task needs; re-auth keeps prior grants (incremental). Omit for all domains |
 | App Store Connect | `mimi-seed auth appstore` → verify with `appstore_verify_credentials` |
 | Play service account | `mimi-seed auth playstore`, or register per-package with `playstore_register_service_account`. **Optional** — the OAuth token carries `androidpublisher`, so this is only needed for headless/CI |
 | BigQuery | `mimi-seed auth bigquery` (optional — OAuth works too) |
@@ -153,7 +154,7 @@ per-domain inventory is [`docs/domain/tool-catalog.md`](domain/tool-catalog.md).
 | **Facebook / Instagram / Threads** | `facebook_post_photo` · `instagram_post_carousel` · `threads_post` · `threads_refresh_token` |
 | **Checks** | `playstore_check_submission_risks` · `appstore_check_submission_risks` · `screenshot_validate` · `release_status` |
 | **AI / Auth** | `generate_release_notes_from_commits` · `generate_review_reply` · `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
-| **Video production** | `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
+| **Video production** | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
 
 ---
 

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Mimi Seed MCP server — Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/__tests__/auth-scopes.test.ts
+++ b/packages/mcp-server/src/__tests__/auth-scopes.test.ts
@@ -27,6 +27,7 @@ describe('auth/scopes — 도메인 → 스코프 매핑 SSOT', () => {
         'https://www.googleapis.com/auth/webmasters',
         'https://www.googleapis.com/auth/analytics.edit',
         'https://www.googleapis.com/auth/analytics.readonly',
+        'https://www.googleapis.com/auth/youtube.force-ssl',
       ].sort(),
     );
   });
@@ -61,6 +62,7 @@ describe('auth/scopes — 도메인 → 스코프 매핑 SSOT', () => {
   it('domainsForScope: cloud-platform → gcp (INSUFFICIENT_SCOPE 안내에 사용)', () => {
     expect(domainsForScope(CLOUD_PLATFORM_SCOPE)).toEqual(['gcp']);
     expect(domainsForScope('https://www.googleapis.com/auth/analytics.readonly')).toEqual(['ga4']);
+    expect(domainsForScope('https://www.googleapis.com/auth/youtube.force-ssl')).toEqual(['youtube']);
     expect(domainsForScope('https://example.com/unknown')).toEqual([]);
   });
 
@@ -92,6 +94,7 @@ describe('auth/scopes — 도메인 → 스코프 매핑 SSOT', () => {
     expect(isPreTrackingScope('https://www.googleapis.com/auth/androidpublisher')).toBe(true);
     expect(isPreTrackingScope('https://www.googleapis.com/auth/analytics.edit')).toBe(false);
     expect(isPreTrackingScope('https://www.googleapis.com/auth/analytics.readonly')).toBe(false);
+    expect(isPreTrackingScope('https://www.googleapis.com/auth/youtube.force-ssl')).toBe(false);
     // 미래에 추가될 임의의 신규 스코프는 동결 스냅샷에 없으므로 자동으로 false(미보유) —
     // 목록 갱신을 잊어도 pre-flight 가 무력화되지 않는다는 게 핵심 불변식.
     expect(isPreTrackingScope('https://www.googleapis.com/auth/some.future.scope')).toBe(false);

--- a/packages/mcp-server/src/__tests__/youtube-publish.test.ts
+++ b/packages/mcp-server/src/__tests__/youtube-publish.test.ts
@@ -1,0 +1,44 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { __testing } from '../video/youtube-publish.js';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('YouTube publishing safety', () => {
+  it('public/unlisted는 명시 확인 없이는 거부하고 private는 허용한다', () => {
+    expect(() => __testing.assertVisibilityConfirmed('public', false)).toThrow('confirmVisible=true');
+    expect(() => __testing.assertVisibilityConfirmed('unlisted')).toThrow('confirmVisible=true');
+    expect(() => __testing.assertVisibilityConfirmed('public', true)).not.toThrow();
+    expect(() => __testing.assertVisibilityConfirmed('private')).not.toThrow();
+  });
+
+  it('업로드 파일은 존재하는 절대경로와 허용된 영상 확장자만 받는다', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'mimi-seed-youtube-'));
+    dirs.push(dir);
+    mkdirSync(dir, { recursive: true });
+    const mp4 = path.join(dir, 'short.mp4');
+    const txt = path.join(dir, 'not-video.txt');
+    writeFileSync(mp4, Buffer.from('video'));
+    writeFileSync(txt, Buffer.from('text'));
+    expect(__testing.assertUploadFile(mp4)).toMatchObject({ mimeType: 'video/mp4', size: 5 });
+    expect(() => __testing.assertUploadFile('relative.mp4')).toThrow('절대경로');
+    expect(() => __testing.assertUploadFile(txt)).toThrow('지원 영상 형식');
+  });
+
+  it('쇼츠는 세로/정사각형·180초 이하만 허용한다', () => {
+    expect(() => __testing.assertShortsCompatible({ width: 1080, height: 1920, durationSec: 21 })).not.toThrow();
+    expect(() => __testing.assertShortsCompatible({ width: 1920, height: 1080, durationSec: 21 })).toThrow('세로형');
+    expect(() => __testing.assertShortsCompatible({ width: 1080, height: 1920, durationSec: 181 })).toThrow('180초');
+  });
+
+  it('YouTube 태그의 합산 500자 제한을 업로드 전에 검사한다', () => {
+    expect(() => __testing.assertTags(['coffee', 'shorts'])).not.toThrow();
+    expect(() => __testing.assertTags(['a'.repeat(250), 'b'.repeat(250)])).toThrow('500자');
+  });
+});

--- a/packages/mcp-server/src/auth/scopes.ts
+++ b/packages/mcp-server/src/auth/scopes.ts
@@ -71,6 +71,11 @@ export const AUTH_DOMAINS = {
     ],
     summary: 'ga4_* — property/data stream 생성·조회 + 리포트',
   },
+  youtube: {
+    label: 'YouTube',
+    scopes: ['https://www.googleapis.com/auth/youtube.force-ssl'],
+    summary: 'youtube_* — 영상 업로드·처리 상태 조회·공개 상태 변경',
+  },
 } as const satisfies Record<string, AuthDomainDef>;
 
 export type AuthDomainId = keyof typeof AUTH_DOMAINS;

--- a/packages/mcp-server/src/registers/auth.ts
+++ b/packages/mcp-server/src/registers/auth.ts
@@ -155,6 +155,13 @@ export function registerAuthTools(server: McpServer) {
         lines.push('❌ Google OAuth      — 미연결 → mimi_seed_auth_start');
       }
 
+      const youtubeGranted = summarizeGrantedDomains(getStoredTokens()?.scope).granted.includes('youtube');
+      if (youtubeGranted && (oauthResult.status === 'fresh' || oauthResult.status === 'refreshed')) {
+        lines.push('✅ YouTube           — 업로드·상태 관리 권한 연결됨');
+      } else {
+        lines.push('❌ YouTube           — 미연결 → mimi_seed_auth_start(domains=["youtube"])  (선택)');
+      }
+
       // 2. Play Store SA
       const saInfo = listRegisteredServiceAccounts();
       const saCount = saInfo.perPackage.length + (saInfo.default ? 1 : 0);

--- a/packages/mcp-server/src/registers/video.ts
+++ b/packages/mcp-server/src/registers/video.ts
@@ -15,6 +15,13 @@ import {
 } from '../video/providers.js';
 import { getRenderJob, startRender, validateVideo } from '../video/render.js';
 import { synthesizeResearch } from '../video/research.js';
+import { requireAuth } from '../helpers.js';
+import {
+  YOUTUBE_SCOPE,
+  getYouTubeVideoStatus,
+  updateYouTubeVideoPrivacy,
+  uploadYouTubeVideo,
+} from '../video/youtube-publish.js';
 
 function text(value: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
@@ -27,6 +34,63 @@ const httpUrl = z.string().url().refine((value) => {
 }, 'HTTP(S) URL만 허용합니다.');
 
 export function registerVideoTools(server: McpServer) {
+  server.tool(
+    'youtube_upload_video',
+    [
+      '로컬 영상 파일을 현재 Google OAuth 계정의 YouTube 채널에 업로드합니다.',
+      '기본 공개 상태는 private이며 public/unlisted는 같은 턴의 명시 승인 후 confirmVisible=true가 필요합니다.',
+      '업로드 후 youtube_get_video_status로 처리 완료 여부와 실제 공개 상태를 확인하세요.',
+      '요청이 타임아웃되면 업로드가 뒤늦게 완료될 수 있으므로 YouTube Studio를 먼저 확인하고 중복 재시도하지 마세요.',
+      'YouTube OAuth 권한이 없으면 mimi_seed_auth_start(domains=["youtube"])로 증분 연결하세요.',
+    ].join(' '),
+    {
+      filePath: absolutePath.describe('업로드할 .mp4/.mov/.webm 영상 절대경로'),
+      title: z.string().min(1).max(100).describe('YouTube 영상 제목'),
+      description: z.string().max(5_000).optional().describe('영상 설명과 음원 출처/라이선스 표기'),
+      tags: z.array(z.string().min(1).max(500)).max(100).optional(),
+      categoryId: z.string().regex(/^\d+$/).default('24').describe('YouTube 카테고리 ID'),
+      privacyStatus: z.enum(['private', 'unlisted', 'public']).default('private'),
+      madeForKids: z.boolean().default(false),
+      containsSyntheticMedia: z.boolean().optional().describe('현실적으로 보이는 AI 생성·변형 콘텐츠 여부를 YouTube에 고지'),
+      notifySubscribers: z.boolean().default(false),
+      shortsOnly: z.boolean().default(false).describe('true면 세로/정사각형·180초 이하 쇼츠 규격을 강제'),
+      confirmVisible: z.boolean().default(false).describe('public/unlisted 게시에 대한 명시 확인'),
+    },
+    async (input) => {
+      const auth = await requireAuth(YOUTUBE_SCOPE);
+      return text(await uploadYouTubeVideo(auth, input));
+    },
+  );
+
+  server.tool(
+    'youtube_get_video_status',
+    '내 YouTube 영상의 업로드 처리 상태와 현재 공개 상태를 조회합니다.',
+    {
+      videoId: z.string().min(1).max(64).describe('YouTube video ID'),
+    },
+    async ({ videoId }) => {
+      const auth = await requireAuth(YOUTUBE_SCOPE);
+      return text(await getYouTubeVideoStatus(auth, videoId));
+    },
+  );
+
+  server.tool(
+    'youtube_update_video_privacy',
+    [
+      '내 YouTube 영상의 공개 상태를 변경하고 실제 반영 상태를 다시 조회합니다.',
+      'public/unlisted 변경은 같은 턴의 명시 승인 후 confirmVisible=true가 필요합니다.',
+    ].join(' '),
+    {
+      videoId: z.string().min(1).max(64).describe('YouTube video ID'),
+      privacyStatus: z.enum(['private', 'unlisted', 'public']),
+      confirmVisible: z.boolean().default(false).describe('public/unlisted 변경에 대한 명시 확인'),
+    },
+    async (input) => {
+      const auth = await requireAuth(YOUTUBE_SCOPE);
+      return text(await updateYouTubeVideoPrivacy(auth, input));
+    },
+  );
+
   server.tool(
     'video_plan_from_story',
     [

--- a/packages/mcp-server/src/video/youtube-publish.ts
+++ b/packages/mcp-server/src/video/youtube-publish.ts
@@ -1,0 +1,206 @@
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { google, type youtube_v3 } from 'googleapis';
+import type { OAuth2Client } from 'google-auth-library';
+import { friendlyGoogleError } from '../lib/google-errors.js';
+import { validateVideo } from './render.js';
+
+export const YOUTUBE_SCOPE = 'https://www.googleapis.com/auth/youtube.force-ssl';
+
+export type YouTubePrivacyStatus = 'private' | 'unlisted' | 'public';
+
+export interface UploadYouTubeVideoInput {
+  filePath: string;
+  title: string;
+  description?: string;
+  tags?: string[];
+  categoryId?: string;
+  privacyStatus?: YouTubePrivacyStatus;
+  madeForKids?: boolean;
+  containsSyntheticMedia?: boolean;
+  notifySubscribers?: boolean;
+  shortsOnly?: boolean;
+  confirmVisible?: boolean;
+}
+
+export interface UpdateYouTubePrivacyInput {
+  videoId: string;
+  privacyStatus: YouTubePrivacyStatus;
+  confirmVisible?: boolean;
+}
+
+function assertVisibilityConfirmed(privacyStatus: YouTubePrivacyStatus, confirmVisible?: boolean): void {
+  if (privacyStatus !== 'private' && confirmVisible !== true) {
+    throw new Error(`${privacyStatus} 게시에는 confirmVisible=true가 필요합니다.`);
+  }
+}
+
+function assertUploadFile(filePath: string): { size: number; mimeType: string } {
+  if (!path.isAbsolute(filePath) || !existsSync(filePath)) {
+    throw new Error('filePath는 존재하는 절대경로여야 합니다.');
+  }
+  const stat = statSync(filePath);
+  if (!stat.isFile() || stat.size <= 0) throw new Error('업로드할 영상 파일이 비어 있거나 파일이 아닙니다.');
+  const ext = path.extname(filePath).toLowerCase();
+  const mimeType = ext === '.mp4'
+    ? 'video/mp4'
+    : ext === '.mov'
+      ? 'video/quicktime'
+      : ext === '.webm'
+        ? 'video/webm'
+        : null;
+  if (!mimeType) throw new Error('지원 영상 형식은 .mp4, .mov, .webm입니다.');
+  return { size: stat.size, mimeType };
+}
+
+function assertTags(tags: string[] = []): void {
+  if (tags.join(',').length > 500) throw new Error('tags의 전체 길이는 쉼표를 포함해 500자 이하여야 합니다.');
+}
+
+function videoFacts(validation: Awaited<ReturnType<typeof validateVideo>>): {
+  width?: number;
+  height?: number;
+  durationSec?: number;
+} {
+  const stream = validation.streams.find((item) =>
+    typeof item === 'object' && item !== null && (item as Record<string, unknown>).codec_type === 'video',
+  ) as Record<string, unknown> | undefined;
+  const format = validation.format as Record<string, unknown>;
+  const width = Number(stream?.width);
+  const height = Number(stream?.height);
+  const durationSec = Number(format.duration);
+  return {
+    width: Number.isFinite(width) ? width : undefined,
+    height: Number.isFinite(height) ? height : undefined,
+    durationSec: Number.isFinite(durationSec) ? durationSec : undefined,
+  };
+}
+
+function assertShortsCompatible(facts: ReturnType<typeof videoFacts>): void {
+  if (!facts.width || !facts.height || !facts.durationSec) {
+    throw new Error('쇼츠 규격을 확인할 영상 정보를 읽지 못했습니다.');
+  }
+  if (facts.width > facts.height) throw new Error('shortsOnly=true일 때 영상은 정사각형 또는 세로형이어야 합니다.');
+  if (facts.durationSec > 180) throw new Error('YouTube Shorts 영상은 180초 이하여야 합니다.');
+}
+
+function safeStatus(video: youtube_v3.Schema$Video) {
+  return {
+    videoId: video.id ?? null,
+    title: video.snippet?.title ?? null,
+    privacyStatus: video.status?.privacyStatus ?? null,
+    uploadStatus: video.status?.uploadStatus ?? null,
+    processingStatus: video.processingDetails?.processingStatus ?? null,
+    processingProgress: video.processingDetails?.processingProgress ?? null,
+    madeForKids: video.status?.madeForKids ?? null,
+    containsSyntheticMedia: video.status?.containsSyntheticMedia ?? null,
+    watchUrl: video.id ? `https://youtu.be/${video.id}` : null,
+    studioUrl: video.id ? `https://studio.youtube.com/video/${video.id}/edit` : null,
+  };
+}
+
+export async function getYouTubeVideoStatus(auth: OAuth2Client, videoId: string) {
+  const youtube = google.youtube({ version: 'v3', auth });
+  try {
+    const response = await youtube.videos.list({
+      part: ['snippet', 'status', 'processingDetails'],
+      id: [videoId],
+    });
+    const video = response.data.items?.[0];
+    if (!video) throw new Error(`YouTube 영상을 찾지 못했습니다: ${videoId}`);
+    return safeStatus(video);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('YouTube 영상을 찾지 못했습니다')) throw error;
+    throw friendlyGoogleError(error);
+  }
+}
+
+export async function uploadYouTubeVideo(auth: OAuth2Client, input: UploadYouTubeVideoInput) {
+  const privacyStatus = input.privacyStatus ?? 'private';
+  assertVisibilityConfirmed(privacyStatus, input.confirmVisible);
+  const file = assertUploadFile(input.filePath);
+  if (!input.title.trim() || input.title.length > 100) throw new Error('title은 1~100자여야 합니다.');
+  if ((input.description?.length ?? 0) > 5_000) throw new Error('description은 5,000자 이하여야 합니다.');
+  assertTags(input.tags);
+
+  const validation = await validateVideo(input.filePath);
+  const facts = videoFacts(validation);
+  if (!validation.streams.some((item) =>
+    typeof item === 'object' && item !== null && (item as Record<string, unknown>).codec_type === 'video')) {
+    throw new Error('업로드 파일에 비디오 스트림이 없습니다.');
+  }
+  if (input.shortsOnly) assertShortsCompatible(facts);
+
+  const youtube = google.youtube({ version: 'v3', auth });
+  try {
+    const response = await youtube.videos.insert({
+      part: ['snippet', 'status'],
+      notifySubscribers: input.notifySubscribers ?? false,
+      requestBody: {
+        snippet: {
+          title: input.title.trim(),
+          description: input.description ?? '',
+          tags: input.tags ?? [],
+          categoryId: input.categoryId ?? '24',
+        },
+        status: {
+          privacyStatus,
+          selfDeclaredMadeForKids: input.madeForKids ?? false,
+          ...(typeof input.containsSyntheticMedia === 'boolean'
+            ? { containsSyntheticMedia: input.containsSyntheticMedia }
+            : {}),
+        },
+      },
+      media: {
+        mimeType: file.mimeType,
+        body: createReadStream(input.filePath),
+      },
+    });
+    const videoId = response.data.id;
+    if (!videoId) throw new Error('YouTube 업로드 응답에 videoId가 없습니다.');
+    return {
+      ...safeStatus(response.data),
+      requestedPrivacyStatus: privacyStatus,
+      file: { path: input.filePath, size: file.size, ...facts },
+      validationWarnings: validation.issues,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('videoId')) throw error;
+    throw friendlyGoogleError(error);
+  }
+}
+
+export async function updateYouTubeVideoPrivacy(auth: OAuth2Client, input: UpdateYouTubePrivacyInput) {
+  assertVisibilityConfirmed(input.privacyStatus, input.confirmVisible);
+  const youtube = google.youtube({ version: 'v3', auth });
+  try {
+    const currentResponse = await youtube.videos.list({ part: ['status'], id: [input.videoId] });
+    const current = currentResponse.data.items?.[0];
+    if (!current) throw new Error(`YouTube 영상을 찾지 못했습니다: ${input.videoId}`);
+    await youtube.videos.update({
+      part: ['status'],
+      requestBody: {
+        id: input.videoId,
+        status: {
+          privacyStatus: input.privacyStatus,
+          embeddable: current.status?.embeddable ?? true,
+          license: current.status?.license ?? 'youtube',
+          publicStatsViewable: current.status?.publicStatsViewable ?? true,
+          selfDeclaredMadeForKids: current.status?.selfDeclaredMadeForKids ?? false,
+          containsSyntheticMedia: current.status?.containsSyntheticMedia ?? false,
+        },
+      },
+    });
+    return await getYouTubeVideoStatus(auth, input.videoId);
+  } catch (error) {
+    throw friendlyGoogleError(error);
+  }
+}
+
+export const __testing = {
+  assertVisibilityConfirmed,
+  assertUploadFile,
+  assertTags,
+  assertShortsCompatible,
+  videoFacts,
+};

--- a/packages/mcp-server/tool-manifest.json
+++ b/packages/mcp-server/tool-manifest.json
@@ -1,6 +1,6 @@
 {
   "$comment": "등록된 MCP 도구 + 도메인 메타데이터(label·credential·summary)의 SSOT. src/__tests__/tool-manifest.test.ts 가 실제 서버 등록 목록과 diff 하고 메타데이터 정합성을 검사한다. 도구 추가/삭제/개명 시 이 파일을 함께 갱신할 것 — 산문 문서에는 정확한 개수를 쓰지 말고 이 파일을 가리킬 것. mimi-seed://tools/catalog 리소스가 이 파일을 그대로 서빙한다.",
-  "total": 174,
+  "total": 177,
   "domains": {
     "admob": {
       "label": "AdMob",
@@ -293,9 +293,12 @@
     },
     "video": {
       "label": "영상 제작",
-      "credential": "ANTHROPIC_API_KEY / YOUTUBE_API_KEY / PEXELS_API_KEY / OPENAI_API_KEY + FFmpeg (기능별 선택)",
-      "summary": "story 스토리보드·유사 영상 리서치·라이선스 자산/이미지 생성·타임라인·MP4 렌더",
+      "credential": "기능별 API 키 + Google OAuth(YouTube 게시) + FFmpeg",
+      "summary": "story 스토리보드·영상 리서치/제작·YouTube 업로드와 공개 상태 관리",
       "tools": [
+        "youtube_upload_video",
+        "youtube_get_video_status",
+        "youtube_update_video_privacy",
         "video_plan_from_story",
         "video_research_youtube",
         "video_search_stock_assets",

--- a/plugins/mimi-seed/.codex-plugin/plugin.json
+++ b/plugins/mimi-seed/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect를 Codex에서 관리하는 MCP 도구와 출시 운영 스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/plugins/mimi-seed/docs/agent-guide.md
+++ b/plugins/mimi-seed/docs/agent-guide.md
@@ -57,6 +57,7 @@ tools directly — but the *call order* and *safety rules* below still apply.
 | CI (GitHub/GitLab) | `select:ci_save_config,ci_list_workflows,ci_trigger_build,ci_get_build_status,ci_list_recent_builds` |
 | Service account end-to-end | `select:iam_create_service_account,iam_create_key,iam_add_iam_policy_binding,playstore_register_service_account,playstore_verify_service_account` |
 | Story → researched video | `select:video_plan_from_story,video_research_youtube,video_search_stock_assets,video_synthesize_research,video_download_stock_assets,video_generate_image,video_add_local_asset,video_build_timeline,video_render,video_job_status,video_validate` |
+| YouTube upload / publish | `select:youtube_upload_video,youtube_get_video_status,youtube_update_video_privacy,mimi_seed_auth_start` |
 
 ---
 
@@ -80,7 +81,7 @@ every credential, which also tells them where to obtain each token
 
 | Service | Fix |
 |---------|-----|
-| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login`. Both accept a **domain subset** (`domains=["ga4","googleads"]` / `--domains ga4,googleads`) — request only what the task needs; re-auth keeps prior grants (incremental). Omit for all domains |
+| Google (Firebase/AdMob/Play/Ads/GSC/GA4/IAM/BigQuery/YouTube) | tool `mimi_seed_auth_start` → give the user the OAuth URL, **or** `mimi-seed auth login`. Both accept a **domain subset** (`domains=["youtube"]` / `--domains youtube`) — request only what the task needs; re-auth keeps prior grants (incremental). Omit for all domains |
 | App Store Connect | `mimi-seed auth appstore` → verify with `appstore_verify_credentials` |
 | Play service account | `mimi-seed auth playstore`, or register per-package with `playstore_register_service_account`. **Optional** — the OAuth token carries `androidpublisher`, so this is only needed for headless/CI |
 | BigQuery | `mimi-seed auth bigquery` (optional — OAuth works too) |
@@ -153,7 +154,7 @@ per-domain inventory is [`docs/domain/tool-catalog.md`](domain/tool-catalog.md).
 | **Facebook / Instagram / Threads** | `facebook_post_photo` · `instagram_post_carousel` · `threads_post` · `threads_refresh_token` |
 | **Checks** | `playstore_check_submission_risks` · `appstore_check_submission_risks` · `screenshot_validate` · `release_status` |
 | **AI / Auth** | `generate_release_notes_from_commits` · `generate_review_reply` · `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
-| **Video production** | `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
+| **Video production** | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
 
 ---
 

--- a/plugins/mimi-seed/docs/credentials.ko.md
+++ b/plugins/mimi-seed/docs/credentials.ko.md
@@ -47,7 +47,7 @@ Cloud IAM · BigQuery 가 모두 같은 OAuth 토큰을 탄다. 여기서 시작
 
 ## Google OAuth
 
-**열리는 것:** `firebase_*`, `admob_*`, `playstore_*`, `googleads_*`, `gsc_*`, `ga4_*`, `iam_*`, `bigquery_*`
+**열리는 것:** `firebase_*`, `admob_*`, `playstore_*`, `googleads_*`, `gsc_*`, `ga4_*`, `iam_*`, `bigquery_*`, `youtube_*`
 
 **먼저 필요한 것:** Google 계정. 그게 전부다.
 

--- a/plugins/mimi-seed/docs/credentials.md
+++ b/plugins/mimi-seed/docs/credentials.md
@@ -47,7 +47,7 @@ and BigQuery all ride on the same OAuth token. Start there.
 
 ## Google OAuth
 
-**Unlocks:** `firebase_*`, `admob_*`, `playstore_*`, `googleads_*`, `gsc_*`, `ga4_*`, `iam_*`, `bigquery_*`
+**Unlocks:** `firebase_*`, `admob_*`, `playstore_*`, `googleads_*`, `gsc_*`, `ga4_*`, `iam_*`, `bigquery_*`, `youtube_*`
 
 **You need first:** a Google account. That's all.
 

--- a/plugins/mimi-seed/docs/domain/auth-credentials.md
+++ b/plugins/mimi-seed/docs/domain/auth-credentials.md
@@ -56,10 +56,12 @@ All under `~/.mimi-seed/` (legacy `~/.preseed/` is still read as a fallback):
 
 The Google OAuth login no longer forces the full scope list. The SSOT for the **auth-domain → scope**
 mapping is `mcp-server/src/auth/scopes.ts` (`AUTH_DOMAINS`: `firebase`, `gcp`, `admob`, `playstore`,
-`googleads`, `gsc`, `ga4`) — least-privilege consent for the OAuth verification "minimum scopes" requirement:
+`googleads`, `gsc`, `ga4`, `youtube`) — least-privilege consent for the OAuth verification "minimum scopes" requirement:
 
 - `mimi-seed-auth --domains ga4,googleads` (CLI) and `mimi_seed_auth_start(domains=[…])` (MCP) request only
   the selected domains' scopes; omitting the option requests everything (old behavior).
+- The `youtube` domain unlocks video upload, processing/status reads, and privacy changes without introducing
+  a second credential store.
 - Requests are sent with `include_granted_scopes=true`, so a re-login **adds** the new scopes on top of the
   existing grant instead of replacing it. `tokens.json` stores the cumulative granted `scope` string.
 - `requireAuth(<scope>)` in `helpers.ts` pre-flights a tool's required scope against the stored grant and, on

--- a/plugins/mimi-seed/docs/domain/external-apis.md
+++ b/plugins/mimi-seed/docs/domain/external-apis.md
@@ -19,6 +19,7 @@
 | GA4 | GA4 Admin + Data APIs | `googleapis` |
 | Search Console | Search Console API | `googleapis` |
 | Google Ads | Google Ads reporting | `googleapis` / REST per `googleads_save_config` |
+| YouTube publishing | YouTube Data API v3 (upload, processing/status, privacy) | `googleapis` + local file streams |
 | App Store Connect | ASC REST API | `fetch` + **`jose`** JWT (ES256, minted per request) |
 | Facebook / Instagram / Threads | Meta Graph APIs | `fetch`; shared expiry/error recovery in `lib/meta-auth.ts` |
 | AI tools | Anthropic Messages API | `@anthropic-ai/sdk` (needs `ANTHROPIC_API_KEY`) |

--- a/plugins/mimi-seed/docs/domain/pitfalls.md
+++ b/plugins/mimi-seed/docs/domain/pitfalls.md
@@ -167,3 +167,8 @@ legitimately exceed the MCP SDK's 60-second default request timeout. Callers tha
 timeout longer than the server's total media-processing budget. If the client still times out, the publish result
 is unknown: inspect the account's latest media before retrying, because the provider may have completed the post
 after the client stopped waiting.
+
+The same unknown-result rule applies to `youtube_upload_video`. The upload request streams the local file directly
+and can outlive the MCP client's timeout even though YouTube later finishes creating the video. Never automatically
+retry a timed-out upload. Check YouTube Studio for a matching recent title/file first; if the call returned a
+`videoId`, use `youtube_get_video_status` to reconcile processing and privacy state.

--- a/plugins/mimi-seed/docs/domain/tool-catalog.md
+++ b/plugins/mimi-seed/docs/domain/tool-catalog.md
@@ -1,4 +1,4 @@
-# Tool catalog — 174 tools across 19 domains
+# Tool catalog — 177 tools across 19 domains
 
 > The MCP server's "entities". One row per domain → register file → tools, with **W** (write) and **D**
 > (destructive / near-irreversible) markers. Everything unmarked is read-only.
@@ -29,8 +29,8 @@
 | Auth | `registers/auth.ts` | 4 |
 | Android signing | `registers/android.ts` | 3 |
 | AI | `registers/ai.ts` | 2 |
-| Video production | `registers/video.ts` | 11 |
-| **Total** | **19 modules** | **174** |
+| Video production | `registers/video.ts` | 14 |
+| **Total** | **19 modules** | **177** |
 
 ## Google Play — `registers/playstore.ts` (29) · impl `playstore/tools.ts`
 
@@ -102,10 +102,12 @@
 | Auth (`auth.ts`) | `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
 | AI (`ai.ts`) — needs `ANTHROPIC_API_KEY` | `generate_release_notes_from_commits` · `generate_review_reply` |
 
-## Video production — `registers/video.ts` (11) · impl `video/*.ts`
+## Video production — `registers/video.ts` (14) · impl `video/*.ts`
 
-- Research/read: `video_research_youtube` (metadata/reference-only) · `video_search_stock_assets` ·
-  `video_job_status` · `video_validate`
+- Research/read: `youtube_get_video_status` · `video_research_youtube` (metadata/reference-only) ·
+  `video_search_stock_assets` · `video_job_status` · `video_validate`
+- **W** `youtube_upload_video` (기본 private, public/unlisted는 명시 확인 필수) ·
+  `youtube_update_video_privacy` (public/unlisted는 명시 확인 필수)
 - **W** `video_plan_from_story` (Anthropic + local project) · `video_synthesize_research` (metadata/user notes →
   bounded brief) · `video_download_stock_assets` (Pexels, preview then
   confirm) · `video_generate_image` (OpenAI, preview then confirm) · `video_add_local_asset` ·


### PR DESCRIPTION
## Summary
- add YouTube video upload, processing/status lookup, and privacy update MCP tools
- add least-privilege incremental YouTube OAuth domain and publish safety guards
- sync tool inventory/docs/plugin assets and release version 0.13.0

## Adversarial review fixes
- require explicit confirmation for public/unlisted visibility
- validate file paths, video streams, Shorts dimensions/duration, tag aggregate length, and synthetic-media disclosure
- use youtube.force-ssl instead of the broader youtube scope
- warn against duplicate retries after an unknown upload timeout

## Validation
- npm test (MCP 264, CLI 134)
- npm run plugin:check
- npm pack --dry-run for MCP package
- staged secret scan