### PR TITLE
feat(mcp): 스토어 실매출 리포트 도구 4개 — sandbox·테스터가 섞이지 않는 기준선 (0.17.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed",
   "displayName": "Mimi Seed",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube 게시를 Claude Code에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/README.ko.md
+++ b/README.ko.md
@@ -391,8 +391,8 @@ SDK에 기여한다면 **도메인 온톨로지** [`docs/domain/`](docs/domain/)
 
 | 영역 | 도구 수 | 주요 도구 |
 |------|---------|-----------|
-| **App Store Connect** | 61 | `appstore_submit_for_review` · `appstore_update_product_review_note` · `appstore_upload_product_review_screenshot` |
-| **Google Play** | 37 | `playstore_submit_release` · `playstore_replace_images` · `playstore_reply_review` |
+| **App Store Connect** | 63 | `appstore_submit_for_review` · `appstore_update_product_review_note` · `appstore_upload_product_review_screenshot` |
+| **Google Play** | 39 | `playstore_submit_release` · `playstore_replace_images` · `playstore_reply_review` |
 | **Firebase** | 20 | `firebase_create_project` · `firebase_create_android_app` · `firebase_get_android_config` |
 | **AdMob** | 7 | `admob_create_ad_unit` · `admob_get_today_earnings` · `admob_get_report` |
 | **CI/CD** | 6 | `ci_trigger_build` · `ci_get_build_status` · `ci_list_workflows` (GitHub Actions · GitLab) |

--- a/README.md
+++ b/README.md
@@ -394,8 +394,8 @@ full tool catalog, the auth/credential model, and known pitfalls — start at
 
 | Domain | Count | Key Tools |
 |--------|-------|-----------|
-| **App Store Connect** | 61 | `appstore_submit_for_review` · `appstore_update_product_review_note` · `appstore_upload_product_review_screenshot` |
-| **Google Play** | 37 | `playstore_submit_release` · `playstore_replace_images` · `playstore_reply_review` |
+| **App Store Connect** | 63 | `appstore_submit_for_review` · `appstore_update_product_review_note` · `appstore_upload_product_review_screenshot` |
+| **Google Play** | 39 | `playstore_submit_release` · `playstore_replace_images` · `playstore_reply_review` |
 | **Firebase** | 20 | `firebase_create_project` · `firebase_create_android_app` · `firebase_get_android_config` |
 | **AdMob** | 7 | `admob_create_ad_unit` · `admob_get_today_earnings` · `admob_get_report` |
 | **CI/CD** | 6 | `ci_trigger_build` · `ci_get_build_status` · `ci_list_workflows` (GitHub Actions · GitLab) |

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -70,6 +70,7 @@ you can paste. Pick the row for the job; batching two rows in one `select:` call
 | Analytics wiring (Firebase ↔ GA4 ↔ BigQuery) | `select:firebase_link_analytics,firebase_get_analytics_details,ga4_list_account_summaries,ga4_list_properties,ga4_create_property,ga4_list_data_streams,ga4_create_data_stream,ga4_plan_bigquery_link,ga4_create_bigquery_link,ga4_run_report` |
 | BigQuery | `select:bigquery_auth_status,bigquery_list_datasets,bigquery_list_tables,bigquery_get_table_schema,bigquery_run_query` |
 | GCP billing (Blaze 여부 · 비용 범위 · 예산) | `select:gcp_get_billing_info,gcp_list_billing_projects,gcp_list_budgets,gcp_create_budget` |
+| Real revenue (스토어 정산 원장 — sandbox·테스터가 섞이지 않는 유일한 창구) | `select:appstore_get_sales_report,appstore_get_finance_report,playstore_list_financial_reports,playstore_get_financial_report` |
 | AdMob | `select:admob_list_accounts,admob_list_apps,admob_create_app,admob_create_ad_unit,admob_list_ad_units,admob_get_today_earnings,admob_get_report` |
 | Google Ads (UAC) | `select:googleads_config_status,googleads_save_config,googleads_list_accessible_customers,googleads_list_campaigns,googleads_get_campaign_report,googleads_get_uac_report` |
 | Search Console | `select:gsc_list_sites,gsc_list_sitemaps,gsc_get_sitemap,gsc_submit_sitemap,gsc_inspect_url,gsc_search_analytics` |

--- a/docs/domain/tool-catalog.md
+++ b/docs/domain/tool-catalog.md
@@ -1,4 +1,4 @@
-# Tool catalog — 226 tools across 21 domains
+# Tool catalog — 230 tools across 21 domains
 
 > The MCP server's "entities". One row per domain → register file → tools, with **W** (write) and **D**
 > (destructive / near-irreversible) markers. Everything unmarked is read-only.
@@ -11,8 +11,8 @@
 
 | Domain | Register file | Tools |
 |--------|---------------|------:|
-| App Store Connect | `registers/appstore.ts` | 61 |
-| Google Play | `registers/playstore.ts` | 37 |
+| App Store Connect | `registers/appstore.ts` | 63 |
+| Google Play | `registers/playstore.ts` | 39 |
 | Firebase | `registers/firebase.ts` | 20 |
 | AdMob | `registers/admob.ts` | 7 |
 | CI (GitHub/GitLab) | `registers/ci.ts` | 6 |
@@ -32,14 +32,15 @@
 | Android signing | `registers/android.ts` | 3 |
 | AI | `registers/ai.ts` | 2 |
 | Video production | `registers/video.ts` | 14 |
-| **Total** | **21 modules** | **226** |
+| **Total** | **21 modules** | **230** |
 
-## Google Play — `registers/playstore.ts` (37) · impl `playstore/tools.ts`
+## Google Play — `registers/playstore.ts` (39) · impl `playstore/tools.ts`
 
 - Read: `playstore_list_recovery_actions` · `playstore_get_app` · `playstore_get_listing` · `playstore_list_tracks` · `playstore_get_statistics` ·
   `playstore_list_images` · `playstore_list_reviews` · `playstore_list_inapp_products` ·
   `playstore_list_subscriptions` · `playstore_list_products` · `playstore_list_service_accounts` ·
-  `playstore_verify_service_account` · `playstore_plan_release`
+  `playstore_verify_service_account` · `playstore_plan_release` ·
+  `playstore_list_financial_reports` · `playstore_get_financial_report` (GCS 재무 CSV — Play API 엔 매출 엔드포인트가 없다)
 - **W** `playstore_create_recovery_action` (DRAFT 생성 — 아직 사용자에게 안 나감) ·
   `playstore_upload_data_safety` (데이터 안전 CSV — 기존 제출 전체 덮어씀, confirm 게이트) ·
   `playstore_update_listing` · `playstore_update_details` (developer contact + default language —
@@ -53,7 +54,7 @@
   `playstore_cancel_recovery_action` · `playstore_submit_release` · `playstore_promote_release` · `playstore_delete_all_images` ·
   `playstore_delete_product` · `playstore_delete_service_account`
 
-## App Store Connect — `registers/appstore.ts` (61) · impl `appstore/tools.ts`
+## App Store Connect — `registers/appstore.ts` (63) · impl `appstore/tools.ts`
 
 - Read: `appstore_list_apps` · `appstore_verify_credentials` · `appstore_get_app` · `appstore_list_versions` ·
   `appstore_get_metadata` · `appstore_list_screenshots` · `appstore_get_review_notes` · `appstore_list_builds` ·
@@ -75,6 +76,8 @@
   `appstore_update_product_review_note` · `appstore_update_product_localization` ·
   `appstore_add_product_to_review` ·
   `appstore_upload_product_review_screenshot`
+- Read(매출): `appstore_get_sales_report` (Sales and Trends — sandbox 가 섞이지 않는 실매출 기준선) ·
+  `appstore_get_finance_report` (정산 — reportDate 는 **Apple 회계월**)
 - **U** `appstore_update_version_string` · `appstore_add_version_to_review_submission` ·
   `appstore_update_release_type` (MANUAL / AFTER_APPROVAL / SCHEDULED 전환) ·
   `appstore_phased_release` (단계적 출시 — `enable`/`pause`/`resume`은 되돌릴 수 있음)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed-sdk",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Monorepo root — the SDK version (SSOT for both packages and client plugin manifests) plus bootstrap scripts. The publishable packages live in packages/. This is NOT an npm workspace: each package installs independently.",
   "type": "module",
   "engines": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Mimi Seed CLI \u2014 Claude Code\uc640 Codex\uc5d0\uc11c \uc571 \ucd9c\uc2dc \uc6b4\uc601\uc744 \uad00\ub9ac\ud569\ub2c8\ub2e4.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -79,8 +79,8 @@ export ANTHROPIC_API_KEY=sk-ant-...
 
 | 영역 | 도구 수 | 주요 도구 |
 |------|---------|-----------|
-| App Store Connect | 61 | `appstore_submit_for_review` / `appstore_upload_screenshot` / `appstore_update_product_review_note` / `appstore_upload_product_review_screenshot` |
-| Google Play | 37 | `playstore_submit_release` / `playstore_promote_release` / `playstore_replace_images` / `playstore_reply_review` / `playstore_verify_service_account` |
+| App Store Connect | 63 | `appstore_submit_for_review` / `appstore_upload_screenshot` / `appstore_update_product_review_note` / `appstore_upload_product_review_screenshot` |
+| Google Play | 39 | `playstore_submit_release` / `playstore_promote_release` / `playstore_replace_images` / `playstore_reply_review` / `playstore_verify_service_account` |
 | Firebase | 20 | `firebase_create_project` / `firebase_create_android_app` / `firebase_get_android_config` / `firebase_create_ios_app` |
 | AdMob | 7 | `admob_list_apps` / `admob_create_ad_unit` / `admob_get_today_earnings` / `admob_get_report` |
 | CI/CD (GitHub Actions · GitLab) | 6 | `ci_trigger_build` / `ci_get_build_status` / `ci_list_workflows` / `ci_cancel_build` |

--- a/packages/mcp-server/assets/agent-guide.md
+++ b/packages/mcp-server/assets/agent-guide.md
@@ -70,6 +70,7 @@ you can paste. Pick the row for the job; batching two rows in one `select:` call
 | Analytics wiring (Firebase ↔ GA4 ↔ BigQuery) | `select:firebase_link_analytics,firebase_get_analytics_details,ga4_list_account_summaries,ga4_list_properties,ga4_create_property,ga4_list_data_streams,ga4_create_data_stream,ga4_plan_bigquery_link,ga4_create_bigquery_link,ga4_run_report` |
 | BigQuery | `select:bigquery_auth_status,bigquery_list_datasets,bigquery_list_tables,bigquery_get_table_schema,bigquery_run_query` |
 | GCP billing (Blaze 여부 · 비용 범위 · 예산) | `select:gcp_get_billing_info,gcp_list_billing_projects,gcp_list_budgets,gcp_create_budget` |
+| Real revenue (스토어 정산 원장 — sandbox·테스터가 섞이지 않는 유일한 창구) | `select:appstore_get_sales_report,appstore_get_finance_report,playstore_list_financial_reports,playstore_get_financial_report` |
 | AdMob | `select:admob_list_accounts,admob_list_apps,admob_create_app,admob_create_ad_unit,admob_list_ad_units,admob_get_today_earnings,admob_get_report` |
 | Google Ads (UAC) | `select:googleads_config_status,googleads_save_config,googleads_list_accessible_customers,googleads_list_campaigns,googleads_get_campaign_report,googleads_get_uac_report` |
 | Search Console | `select:gsc_list_sites,gsc_list_sitemaps,gsc_get_sitemap,gsc_submit_sitemap,gsc_inspect_url,gsc_search_analytics` |

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Mimi Seed MCP server \u2014 Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/appstore/auth.ts
+++ b/packages/mcp-server/src/appstore/auth.ts
@@ -14,6 +14,13 @@ export interface AppStoreCredentials {
   issuerId: string;   // App Store Connect > Users and Access > Keys > Issuer ID
   keyId: string;      // Key ID
   privateKey: string; // .p8 파일 내용
+  /**
+   * Sales and Trends / Finance 리포트 전용 판매자 번호.
+   *
+   * **API 로는 조회할 수 없다** — ASC > 지급 및 재무 보고서 화면에서 눈으로 읽어
+   * 여기 적어두는 수밖에 없다. 리포트 도구에만 쓰이므로 없어도 나머지는 다 동작한다.
+   */
+  vendorNumber?: string;
 }
 
 export function getAppStoreCredentials(): AppStoreCredentials | null {

--- a/packages/mcp-server/src/appstore/sales.ts
+++ b/packages/mcp-server/src/appstore/sales.ts
@@ -1,0 +1,252 @@
+// App Store Connect Sales and Trends / Finance 리포트.
+//
+// 왜 별도 모듈인가: 이 두 엔드포인트만 **JSON 이 아니다.** gzip 으로 압축된 TSV 를
+// 돌려주므로 appstore/http.ts 의 apiRequest(JSON.parse 전제)를 그대로 쓸 수 없다.
+//
+// 왜 이 도구가 필요한가: GA4 의 in_app_purchase / 자체 결제 이벤트는 **sandbox 를
+// 구분하지 못한다.** TestFlight·Xcode 설치에서 일어난 결제는 실제 청구가 0원인데도
+// 클라이언트 입장에선 성공한 결제라 그대로 이벤트가 나간다. 실매출을 세려면 애초에
+// sandbox 가 들어오지 않는 창구를 봐야 하고, 그게 이 리포트다.
+
+import zlib from 'node:zlib';
+import { fetchWithTimeout } from '../lib/http.js';
+import { getAppStoreCredentials } from './auth.js';
+import { friendlyAppStoreError } from './errors.js';
+import { authHeadersOrThrow, V1_BASE } from './http.js';
+
+/**
+ * vendorNumber 해석: 명시 인자 > ~/.mimi-seed/appstore.json 의 vendorNumber.
+ *
+ * API 로 조회할 방법이 없어서 둘 다 없으면 여기서 끊는다. 빈 문자열로 요청을 보내면
+ * Apple 은 404 를 주는데, 그건 "그 날 매출 0" 과 **구분되지 않는다** — 설정 누락이
+ * 매출 0 으로 둔갑하는 게 이 도구에서 제일 위험한 오답이라 사전에 막는다.
+ */
+function resolveVendorNumber(explicit?: string): string {
+  const vendorNumber = explicit?.trim() || getAppStoreCredentials()?.vendorNumber?.trim();
+  if (!vendorNumber) {
+    throw new Error(
+      [
+        '❌ vendorNumber 가 없어 — 매출 리포트는 판매자 번호가 반드시 필요해.',
+        '',
+        'App Store Connect > 비즈니스(지급 및 재무 보고서) 상단에 있는 8~9자리 숫자야.',
+        'API 로는 조회할 수 없으니 한 번만 저장해 두면 이후 생략할 수 있어:',
+        '  ~/.mimi-seed/appstore.json 에 "vendorNumber": "<번호>" 추가',
+        '또는 이 도구의 vendorNumber 인자로 직접 넘겨.',
+      ].join('\n'),
+    );
+  }
+  return vendorNumber;
+}
+
+export type SalesFrequency = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY';
+
+/** 리포트 한 줄 = TSV 헤더명 → 값. 컬럼 구성은 reportType 마다 다르다. */
+export type ReportRow = Record<string, string>;
+
+/**
+ * gzip TSV 를 받아 헤더 기준 객체 배열로 만든다.
+ *
+ * Apple 은 **데이터가 없는 날짜에 404** 를 준다 — 인증 실패나 잘못된 vendorNumber 도
+ * 같은 404 로 올 수 있어서, 호출부가 "매출 0" 과 "설정 틀림" 을 구분할 수 있도록
+ * 여기서는 빈 배열로 뭉개지 않고 notFound 플래그를 그대로 올려보낸다.
+ */
+async function fetchReport(
+  resourcePath: string,
+  params: Record<string, string>,
+): Promise<{ notFound: boolean; rows: ReportRow[]; raw: string }> {
+  const authHeaders = await authHeadersOrThrow();
+  const query = new URLSearchParams(params).toString();
+  const response = await fetchWithTimeout(`${V1_BASE}${resourcePath}?${query}`, {
+    headers: { ...authHeaders, Accept: 'application/a-gzip' },
+  });
+
+  if (response.status === 404) return { notFound: true, rows: [], raw: '' };
+  if (!response.ok) {
+    throw friendlyAppStoreError(response.status, await response.text());
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  // 빈 리포트는 gzip 헤더조차 없이 0바이트로 오는 경우가 있다.
+  if (buffer.length === 0) return { notFound: false, rows: [], raw: '' };
+
+  let text: string;
+  try {
+    text = zlib.gunzipSync(buffer).toString('utf-8');
+  } catch {
+    // Accept 헤더가 무시되고 평문이 온 경우(에러 본문 포함) — 그대로 파싱을 시도한다.
+    text = buffer.toString('utf-8');
+  }
+
+  return { notFound: false, rows: parseTsv(text), raw: text };
+}
+
+export function parseTsv(text: string): ReportRow[] {
+  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  if (lines.length < 2) return [];
+
+  const headers = lines[0].split('\t').map((h) => h.trim());
+  return lines.slice(1).map((line) => {
+    const cells = line.split('\t');
+    const row: ReportRow = {};
+    headers.forEach((header, i) => {
+      row[header] = (cells[i] ?? '').trim();
+    });
+    return row;
+  });
+}
+
+function toNumber(value: string | undefined): number {
+  const n = Number.parseFloat((value ?? '').replace(/,/g, ''));
+  return Number.isFinite(n) ? n : 0;
+}
+
+export interface SalesLine {
+  sku: string;
+  title: string;
+  /** Apple 의 Product Type Identifier. IA* / IAY 계열이 인앱결제·구독이다. */
+  productType: string;
+  country: string;
+  /** 환불은 **음수 units** 로 들어온다 — 합계에서 자연히 상쇄된다. */
+  units: number;
+  customerPrice: number;
+  customerCurrency: string;
+  /** 개발자 수취액 **1개당** 금액. 총액은 units 를 곱해야 한다. */
+  proceedsPerUnit: number;
+  proceedsCurrency: string;
+  proceedsTotal: number;
+}
+
+export interface SalesSummary {
+  /** 데이터가 존재한 날짜들. 요청 범위 중 리포트가 없던 날은 빠진다. */
+  datesWithData: string[];
+  datesWithoutData: string[];
+  lines: SalesLine[];
+  /** 통화별 개발자 수취액 합계. 통화가 섞이므로 절대 하나로 더하지 않는다. */
+  proceedsByCurrency: Record<string, number>;
+  /** 유료 결제 건수 합계 (customerPrice > 0 인 줄의 units). */
+  paidUnits: number;
+  /** 무료 다운로드/설치 units — 매출과 무관하지만 같은 리포트에 섞여 온다. */
+  freeUnits: number;
+}
+
+/** SALES/SUMMARY 리포트 행을 매출 판독에 필요한 형태로만 좁힌다. */
+function toSalesLine(row: ReportRow): SalesLine {
+  const units = toNumber(row['Units']);
+  const proceedsPerUnit = toNumber(row['Developer Proceeds']);
+  return {
+    sku: row['SKU'] ?? '',
+    title: row['Title'] ?? '',
+    productType: row['Product Type Identifier'] ?? '',
+    country: row['Country Code'] ?? '',
+    units,
+    customerPrice: toNumber(row['Customer Price']),
+    customerCurrency: row['Customer Currency'] ?? '',
+    proceedsPerUnit,
+    proceedsCurrency: row['Currency of Proceeds'] ?? '',
+    proceedsTotal: units * proceedsPerUnit,
+  };
+}
+
+/** 날짜 문자열(YYYY-MM-DD)을 하루씩 증가시키며 나열. endDate 포함. */
+export function eachDate(startDate: string, endDate: string, maxDays: number): string[] {
+  const start = Date.parse(`${startDate}T00:00:00Z`);
+  const end = Date.parse(`${endDate}T00:00:00Z`);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    throw new Error('날짜는 YYYY-MM-DD 형식이어야 해.');
+  }
+  if (end < start) throw new Error('endDate 가 startDate 보다 앞설 수 없어.');
+
+  const dates: string[] = [];
+  for (let t = start; t <= end; t += 86_400_000) {
+    if (dates.length >= maxDays) {
+      throw new Error(
+        `한 번에 조회할 수 있는 일수는 ${maxDays}일까지야. 범위를 나눠서 호출해.`,
+      );
+    }
+    dates.push(new Date(t).toISOString().slice(0, 10));
+  }
+  return dates;
+}
+
+/** DAILY 는 하루에 리포트 하나라, 범위 조회는 날짜별 호출을 합치는 수밖에 없다. */
+const MAX_DAILY_RANGE = 62;
+
+export async function getSalesReport(
+  options: {
+    vendorNumber?: string;
+    startDate: string;
+    endDate?: string;
+    frequency?: SalesFrequency;
+    reportType?: string;
+    reportSubType?: string;
+    version?: string;
+  },
+): Promise<SalesSummary> {
+  const vendorNumber = resolveVendorNumber(options.vendorNumber);
+  const frequency = options.frequency ?? 'DAILY';
+  const endDate = options.endDate ?? options.startDate;
+
+  // DAILY 만 날짜를 펼친다. WEEKLY/MONTHLY/YEARLY 는 reportDate 자체가 기간을 뜻해서
+  // 하루씩 도는 게 의미가 없고, 오히려 같은 기간을 며칠치 중복 합산하게 된다.
+  const reportDates =
+    frequency === 'DAILY' ? eachDate(options.startDate, endDate, MAX_DAILY_RANGE) : [options.startDate];
+
+  const datesWithData: string[] = [];
+  const datesWithoutData: string[] = [];
+  const rows: ReportRow[] = [];
+
+  for (const reportDate of reportDates) {
+    const result = await fetchReport(
+      '/salesReports',
+      {
+        'filter[frequency]': frequency,
+        'filter[reportType]': options.reportType ?? 'SALES',
+        'filter[reportSubType]': options.reportSubType ?? 'SUMMARY',
+        'filter[vendorNumber]': vendorNumber,
+        'filter[reportDate]': reportDate,
+        'filter[version]': options.version ?? '1_0',
+      },
+    );
+
+    if (result.notFound || result.rows.length === 0) datesWithoutData.push(reportDate);
+    else {
+      datesWithData.push(reportDate);
+      rows.push(...result.rows);
+    }
+  }
+
+  const lines = rows.map(toSalesLine);
+  const proceedsByCurrency: Record<string, number> = {};
+  let paidUnits = 0;
+  let freeUnits = 0;
+
+  for (const line of lines) {
+    if (line.proceedsTotal !== 0) {
+      const currency = line.proceedsCurrency || 'UNKNOWN';
+      proceedsByCurrency[currency] = (proceedsByCurrency[currency] ?? 0) + line.proceedsTotal;
+    }
+    if (line.customerPrice > 0) paidUnits += line.units;
+    else freeUnits += line.units;
+  }
+
+  for (const currency of Object.keys(proceedsByCurrency)) {
+    proceedsByCurrency[currency] = Math.round(proceedsByCurrency[currency] * 100) / 100;
+  }
+
+  return { datesWithData, datesWithoutData, lines, proceedsByCurrency, paidUnits, freeUnits };
+}
+
+export async function getFinanceReport(options: {
+  vendorNumber?: string;
+  /** YYYY-MM. **Apple 회계월**이라 달력월과 어긋날 수 있다 — 도구 설명 참고. */
+  reportDate: string;
+  regionCode?: string;
+  reportType?: 'FINANCIAL' | 'FINANCE_DETAIL';
+}): Promise<{ notFound: boolean; rows: ReportRow[]; raw: string }> {
+  return fetchReport('/financeReports', {
+    'filter[vendorNumber]': resolveVendorNumber(options.vendorNumber),
+    'filter[reportDate]': options.reportDate,
+    'filter[regionCode]': options.regionCode ?? 'ZZ',
+    'filter[reportType]': options.reportType ?? 'FINANCIAL',
+  });
+}

--- a/packages/mcp-server/src/playstore/financials.ts
+++ b/packages/mcp-server/src/playstore/financials.ts
@@ -1,0 +1,405 @@
+// Google Play 재무 리포트 (Cloud Storage).
+//
+// **Play Developer API 에는 매출 엔드포인트가 없다.** purchases.* 는 구매 토큰을 이미
+// 알고 있어야 하고, Reporting API 는 vitals 뿐이다. 실제 정산 데이터는 Play Console 이
+// 매달 개발자 소유 GCS 버킷에 떨궈주는 CSV 가 유일한 소스라서, 여기서는 그걸 읽는다.
+//
+// 왜 중요한가: GA4 의 결제 이벤트는 라이선스 테스터·내부 테스트 트랙 결제를 실결제와
+// 구분하지 못한다(둘 다 install_source 가 com.android.vending 이다). 청구가 0원인
+// 테스터 주문은 **이 리포트에 아예 나타나지 않으므로**, 실매출 판별의 기준선이 된다.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { JWT } from 'google-auth-library';
+import { fetchWithTimeout, HTTP_TRANSFER_TIMEOUT_MS } from '../lib/http.js';
+import { requireServiceAccountJson } from '../helpers.js';
+
+const CONFIG_PATH = path.join(os.homedir(), '.mimi-seed', 'play-financials.json');
+const STORAGE_SCOPE = 'https://www.googleapis.com/auth/devstorage.read_only';
+
+export type PlayFinancialReportType = 'earnings' | 'sales';
+
+/** 리포트 종류 → 버킷 내 접두사·파일명 규칙. */
+const REPORT_PREFIX: Record<PlayFinancialReportType, string> = {
+  earnings: 'earnings/',
+  sales: 'sales/',
+};
+
+/**
+ * 버킷 이름 해석: 명시 인자 > ~/.mimi-seed/play-financials.json.
+ *
+ * 버킷 이름은 Play Console 에만 있고 API 로 못 얻는다(개발자 계정마다 다르다).
+ * 없으면 조용히 빈 결과를 주는 대신 여기서 끊는다 — "매출 0" 과 "설정 누락" 이
+ * 구분되지 않는 게 이 도구의 가장 위험한 오답이다.
+ */
+export function resolveBucket(explicit?: string, packageName?: string): string {
+  const fromArg = explicit?.trim();
+  if (fromArg) return normalizeBucket(fromArg);
+
+  let config: Record<string, string> = {};
+  try {
+    if (fs.existsSync(CONFIG_PATH)) config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
+  } catch {
+    // 손상된 설정은 없는 것으로 취급하고 아래 안내로 떨어뜨린다.
+  }
+
+  const stored = (packageName && config[packageName]) || config.default || config.bucket;
+  if (stored) return normalizeBucket(stored);
+
+  throw new Error(
+    [
+      '❌ Play 재무 리포트 버킷을 몰라 — API 로는 알아낼 수 없어.',
+      '',
+      'Play Console > 다운로드 보고서 > 재무 화면 아래쪽에 있는',
+      '  gs://pubsite_prod_XXXXXXXXXXXXXXXXXXX',
+      '이 버킷 이름을 한 번만 저장해 두면 이후 생략할 수 있어:',
+      `  ${CONFIG_PATH} 에 {"default": "pubsite_prod_..."}`,
+      '패키지마다 다르면 {"<packageName>": "pubsite_prod_..."} 로 키를 나눠도 돼.',
+      '또는 이 도구의 bucket 인자로 직접 넘겨.',
+      '',
+      '⚠️ 접근 권한은 **GCP IAM 이 아니라 Play Console 권한**이다 — 아래 403 안내 참고.',
+    ].join('\n'),
+  );
+}
+
+function normalizeBucket(raw: string): string {
+  return raw.replace(/^gs:\/\//, '').replace(/\/+$/, '');
+}
+
+/**
+ * GCS 전용 JWT.
+ *
+ * 기존 Play SA 클라이언트(getServiceAccountClient)에 storage 스코프를 얹지 않고 따로
+ * 만든다 — 그쪽은 모든 Play 도구가 공유하는 경로라, 리포트 하나 때문에 스코프를 넓히면
+ * 실패 범위가 도구 전체로 번진다.
+ */
+function storageClient(packageName?: string): JWT {
+  const parsed = JSON.parse(requireServiceAccountJson(packageName));
+  return new JWT({
+    email: parsed.client_email,
+    key: parsed.private_key,
+    scopes: [STORAGE_SCOPE],
+  });
+}
+
+async function storageFetch(client: JWT, url: string, timeoutMs?: number): Promise<Response> {
+  const token = await client.getAccessToken();
+  const response = await fetchWithTimeout(
+    url,
+    { headers: { Authorization: `Bearer ${token.token ?? ''}` } },
+    timeoutMs,
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    if (response.status === 403) {
+      throw new Error(
+        [
+          '❌ 버킷 접근 거부 (403).',
+          '',
+          '⚠️ **GCP IAM 으로는 못 고친다.** pubsite_prod_* 버킷은 개발자 프로젝트가 아니라',
+          'Google 소유라, 프로젝트에 roles/storage.* 를 아무리 줘도 닿지 않는다.',
+          '접근은 오직 **Play Console 사용자 권한**으로 열린다:',
+          '',
+          '  Play Console > 사용자 및 권한 > 새 사용자 초대',
+          '  → 서비스 계정 이메일(...iam.gserviceaccount.com)을 그대로 초대하고',
+          '  → "앱 정보 보기(읽기 전용)" = 전체(Global)',
+          '  → "재무 데이터 보기" = **전체(Global)**  ← 재무 리포트는 이게 없으면 무조건 403',
+          '',
+          '반영에 몇 분 걸릴 수 있다. Play Developer API 접근(앱 게시용)과는 별개 권한이라,',
+          '릴리스가 잘 돌아간다고 해서 리포트가 열려 있는 것은 아니다.',
+          '',
+          body.slice(0, 500),
+        ].join('\n'),
+      );
+    }
+    throw new Error(`❌ Cloud Storage ${response.status}: ${body.slice(0, 500)}`);
+  }
+  return response;
+}
+
+export interface FinancialReportObject {
+  name: string;
+  size: number;
+  updated: string;
+  /** 파일명에서 뽑은 YYYYMM. 못 뽑으면 빈 문자열. */
+  yearMonth: string;
+}
+
+export async function listFinancialReports(options: {
+  packageName?: string;
+  bucket?: string;
+  reportType?: PlayFinancialReportType;
+}): Promise<{ bucket: string; objects: FinancialReportObject[] }> {
+  const bucket = resolveBucket(options.bucket, options.packageName);
+  const client = storageClient(options.packageName);
+
+  // 반드시 페이지를 끝까지 돈다. 이 버킷에는 stats/ 하위 CSV 가 수천 개 쌓여 있어서
+  // 첫 페이지만 읽으면 earnings/·sales/ 가 통째로 안 보인다 — 그런데 응답은 성공이라
+  // "그 달 리포트가 없다"는 오답으로 조용히 둔갑한다. prefix 를 줘도 마찬가지다.
+  const items: Array<Record<string, string>> = [];
+  let pageToken: string | undefined;
+  do {
+    const params = new URLSearchParams({ maxResults: '1000' });
+    if (options.reportType) params.set('prefix', REPORT_PREFIX[options.reportType]);
+    if (pageToken) params.set('pageToken', pageToken);
+
+    const response = await storageFetch(
+      client,
+      `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}/o?${params}`,
+    );
+    const page = (await response.json()) as {
+      items?: Array<Record<string, string>>;
+      nextPageToken?: string;
+    };
+    items.push(...(page.items ?? []));
+    pageToken = page.nextPageToken;
+  } while (pageToken);
+
+  const objects = items.map((item) => ({
+    name: item.name ?? '',
+    size: Number.parseInt(item.size ?? '0', 10) || 0,
+    updated: item.updated ?? '',
+    yearMonth: /_(\d{6})[_.]/.exec(item.name ?? '')?.[1] ?? '',
+  }));
+
+  objects.sort((a, b) => b.name.localeCompare(a.name));
+  return { bucket, objects };
+}
+
+export interface EarningsSummary {
+  bucket: string;
+  files: string[];
+  rowCount: number;
+  /** 정산 통화별 순액 합계 — 수수료·세금·환불이 음수로 들어와 이미 상쇄된 값이다. */
+  netByMerchantCurrency: Record<string, number>;
+  /** Transaction Type 별 건수·금액. 'Charge' 만이 실제 구매다. */
+  byTransactionType: Record<string, { count: number; amount: number }>;
+  /**
+   * 상품별 집계 (Charge 행만). **통화별로 행이 갈린다** — 여러 통화를 한 숫자로 더하면
+   * IDR 1,000,000 과 KRW 3,000 이 섞여 아무 의미 없는 값이 된다.
+   */
+  byProduct: Array<{ productId: string; title: string; currency: string; count: number; amount: number }>;
+  /** 판독을 위해 남기는 원본 행. 기본은 생략된다. */
+  rows?: Array<Record<string, string>>;
+}
+
+export async function getFinancialReport(options: {
+  yearMonth: string;
+  packageName?: string;
+  bucket?: string;
+  reportType?: PlayFinancialReportType;
+  includeRows?: boolean;
+}): Promise<EarningsSummary> {
+  const reportType = options.reportType ?? 'earnings';
+  const bucket = resolveBucket(options.bucket, options.packageName);
+  const client = storageClient(options.packageName);
+
+  const yearMonth = options.yearMonth.replace('-', '');
+  if (!/^\d{6}$/.test(yearMonth)) {
+    throw new Error('yearMonth 는 YYYYMM 또는 YYYY-MM 형식이어야 해.');
+  }
+
+  const { objects } = await listFinancialReports({
+    packageName: options.packageName,
+    bucket,
+    reportType,
+  });
+  // 정산 통화마다 파일이 따로 떨어지므로(earnings_YYYYMM_<id>-<currency>.zip) 한 달이
+  // 파일 하나라고 가정하면 통화 하나만 세고 나머지를 조용히 버리게 된다.
+  const targets = objects.filter((o) => o.name.includes(yearMonth));
+  if (targets.length === 0) {
+    throw new Error(
+      [
+        `❌ ${yearMonth} 의 ${reportType} 리포트가 버킷에 없어.`,
+        '',
+        'Play 재무 리포트는 **월 마감 후에야** 올라온다 — 이번 달 것은 아직 없는 게 정상이다.',
+        `버킷에 있는 파일: ${objects.slice(0, 10).map((o) => o.name).join(', ') || '(없음)'}`,
+      ].join('\n'),
+    );
+  }
+
+  const rows: Array<Record<string, string>> = [];
+  for (const target of targets) {
+    const response = await storageFetch(
+      client,
+      `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}` +
+        `/o/${encodeURIComponent(target.name)}?alt=media`,
+      HTTP_TRANSFER_TIMEOUT_MS,
+    );
+    const zipped = Buffer.from(await response.arrayBuffer());
+    for (const entry of unzip(zipped)) {
+      rows.push(...parseCsv(entry.toString('utf-8')));
+    }
+  }
+
+  return {
+    bucket,
+    files: targets.map((t) => t.name),
+    rowCount: rows.length,
+    ...summarize(rows),
+    ...(options.includeRows ? { rows } : {}),
+  };
+}
+
+/** earnings/sales 양쪽 컬럼명을 모두 받아, 있는 쪽으로 집계한다. */
+function summarize(rows: Array<Record<string, string>>) {
+  const netByMerchantCurrency: Record<string, number> = {};
+  const byTransactionType: Record<string, { count: number; amount: number }> = {};
+  const byProductMap = new Map<
+    string,
+    { productId: string; title: string; currency: string; count: number; amount: number }
+  >();
+
+  for (const row of rows) {
+    const currency = row['Merchant Currency'] || row['Currency of Sale'] || 'UNKNOWN';
+    const amount = toNumber(
+      row['Amount (Merchant Currency)'] ?? row['Charged Amount'] ?? row['Item Price'],
+    );
+    const type = row['Transaction Type'] || row['Financial Status'] || 'UNKNOWN';
+    // 컬럼명이 리포트마다 다르다. earnings 는 'Product id'/'Sku Id', sales 는 **'SKU ID'**
+    // (전부 대문자). 하나라도 빠뜨리면 상품별 집계가 통째로 빈 키('')로 뭉개진다.
+    const productId =
+      row['Product id'] || row['Product ID'] || row['SKU ID'] || row['Sku Id'] ||
+      row['Sku ID'] || row['Package ID'] || '';
+    const title = row['Product Title'] || '';
+
+    netByMerchantCurrency[currency] = (netByMerchantCurrency[currency] ?? 0) + amount;
+
+    const bucketForType = (byTransactionType[type] ??= { count: 0, amount: 0 });
+    bucketForType.count += 1;
+    bucketForType.amount += amount;
+
+    // 수수료·세금 행은 상품 매출이 아니다 — 상품별 집계에 섞으면 판매량이 부풀려진다.
+    if (/^charge$/i.test(type) || /^charged$/i.test(type)) {
+      const key = `${productId || title} ${currency}`;
+      const entry = byProductMap.get(key) ?? { productId, title, currency, count: 0, amount: 0 };
+      entry.count += 1;
+      entry.amount += amount;
+      byProductMap.set(key, entry);
+    }
+  }
+
+  const round = (n: number) => Math.round(n * 100) / 100;
+  for (const key of Object.keys(netByMerchantCurrency)) {
+    netByMerchantCurrency[key] = round(netByMerchantCurrency[key]);
+  }
+  for (const key of Object.keys(byTransactionType)) {
+    byTransactionType[key].amount = round(byTransactionType[key].amount);
+  }
+
+  // 통화가 다른 행끼리는 금액 크기를 비교해도 뜻이 없으므로 통화로 먼저 묶어 정렬한다.
+  const byProduct = [...byProductMap.values()]
+    .map((p) => ({ ...p, amount: round(p.amount) }))
+    .sort((a, b) => a.currency.localeCompare(b.currency) || b.amount - a.amount);
+
+  return { netByMerchantCurrency, byTransactionType, byProduct };
+}
+
+function toNumber(value: string | undefined): number {
+  const n = Number.parseFloat((value ?? '').replace(/[,"]/g, ''));
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * 최소 ZIP 리더 (stored + deflate).
+ *
+ * Node 에 zip 해제가 없고, 이 하나 때문에 의존성을 늘리고 싶지 않다. Play 리포트는
+ * 항상 단일/소수 CSV 엔트리라 중앙 디렉터리만 훑으면 충분하다.
+ */
+export function unzip(buffer: Buffer): Buffer[] {
+  const EOCD_SIG = 0x06054b50;
+  const CEN_SIG = 0x02014b50;
+
+  let eocd = -1;
+  for (let i = buffer.length - 22; i >= 0; i--) {
+    if (buffer.readUInt32LE(i) === EOCD_SIG) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd < 0) throw new Error('ZIP 형식이 아니야 — 재무 리포트 파일이 손상됐을 수 있어.');
+
+  const entryCount = buffer.readUInt16LE(eocd + 10);
+  let offset = buffer.readUInt32LE(eocd + 16);
+  const files: Buffer[] = [];
+
+  for (let i = 0; i < entryCount; i++) {
+    if (buffer.readUInt32LE(offset) !== CEN_SIG) break;
+
+    const method = buffer.readUInt16LE(offset + 10);
+    const compressedSize = buffer.readUInt32LE(offset + 20);
+    const nameLength = buffer.readUInt16LE(offset + 28);
+    const extraLength = buffer.readUInt16LE(offset + 30);
+    const commentLength = buffer.readUInt16LE(offset + 32);
+    const localOffset = buffer.readUInt32LE(offset + 42);
+
+    // 로컬 헤더는 중앙 디렉터리와 extra 필드 길이가 다를 수 있어 반드시 다시 읽는다.
+    const localNameLength = buffer.readUInt16LE(localOffset + 26);
+    const localExtraLength = buffer.readUInt16LE(localOffset + 28);
+    const dataStart = localOffset + 30 + localNameLength + localExtraLength;
+    const data = buffer.subarray(dataStart, dataStart + compressedSize);
+
+    if (method === 0) files.push(Buffer.from(data));
+    else if (method === 8) files.push(zlib.inflateRawSync(data));
+    else throw new Error(`지원하지 않는 ZIP 압축 방식(${method})이야.`);
+
+    offset += 46 + nameLength + extraLength + commentLength;
+  }
+
+  return files;
+}
+
+/** 따옴표·따옴표 안 쉼표를 처리하는 최소 CSV 파서. 헤더 기준 객체 배열을 만든다. */
+export function parseCsv(text: string): Array<Record<string, string>> {
+  const rows = splitCsvRows(text);
+  if (rows.length < 2) return [];
+
+  const headers = rows[0].map((h) => h.trim());
+  return rows.slice(1)
+    .filter((cells) => cells.some((c) => c.trim().length > 0))
+    .map((cells) => {
+      const row: Record<string, string> = {};
+      headers.forEach((header, i) => {
+        row[header] = (cells[i] ?? '').trim();
+      });
+      return row;
+    });
+}
+
+function splitCsvRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let cells: string[] = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else inQuotes = false;
+      } else field += ch;
+      continue;
+    }
+    if (ch === '"') inQuotes = true;
+    else if (ch === ',') {
+      cells.push(field);
+      field = '';
+    } else if (ch === '\n') {
+      cells.push(field);
+      rows.push(cells);
+      cells = [];
+      field = '';
+    } else if (ch !== '\r') field += ch;
+  }
+
+  if (field.length > 0 || cells.length > 0) {
+    cells.push(field);
+    rows.push(cells);
+  }
+  return rows;
+}

--- a/packages/mcp-server/src/registers/appstore.ts
+++ b/packages/mcp-server/src/registers/appstore.ts
@@ -8,6 +8,7 @@ import * as appstoreRelease from '../appstore/release.js';
 import * as appstoreDeclarations from '../appstore/declarations.js';
 import * as testflight from '../appstore/testflight.js';
 import * as previews from '../appstore/previews.js';
+import * as appstoreSales from '../appstore/sales.js';
 import {
   createAppleOneTimePurchase, createAppleSubscription,
   updateAppleProduct, deleteAppleProduct, listAppleProducts,
@@ -1895,5 +1896,72 @@ export function registerAppstoreTools(server: McpServer) {
         : await previews.deletePreviewSet(setId as string);
       return textResult(`✅ 삭제 완료 — ${r.id}`);
     },
+  );
+
+  server.tool(
+    'appstore_get_sales_report',
+    [
+      'Sales and Trends 리포트 = **실매출의 기준선** — GET /v1/salesReports (gzip TSV 를 파싱해 돌려준다).',
+      '분석 이벤트(GA4 in_app_purchase 등)로 매출을 세면 안 되는 이유가 여기 있다:',
+      'TestFlight·Xcode 설치의 결제는 **sandbox 라 청구가 0원인데도** 클라이언트에는 성공한 결제로 보여',
+      '이벤트가 그대로 나간다. 이 리포트에는 sandbox 가 애초에 들어오지 않으므로, 둘을 비교하면',
+      '"진짜 돈이 들어온 건수"가 곧바로 갈린다.',
+      '⚠️ **Developer Proceeds 는 1개당 금액이다** — 총액은 units 를 곱해야 한다(이 도구는 곱해서 준다).',
+      '⚠️ 환불은 units 가 **음수**로 들어와 합계에서 상쇄된다. 즉 합계는 순매출이다.',
+      '⚠️ 데이터가 없는 날짜는 Apple 이 404 를 주므로 datesWithoutData 로 따로 돌려준다 —',
+      '"매출 0" 과 "리포트 미생성/설정 오류"를 섞지 말 것. 당일치는 보통 아직 없다.',
+      'vendorNumber 는 ~/.mimi-seed/appstore.json 에 저장해두면 생략 가능.',
+    ].join(' '),
+    {
+      startDate: z.string().describe('시작일 YYYY-MM-DD (DAILY 가 아니면 이 값이 곧 reportDate)'),
+      endDate: z
+        .string()
+        .optional()
+        .describe('종료일 YYYY-MM-DD (포함). DAILY 에서만 의미가 있고 최대 62일'),
+      frequency: z
+        .enum(['DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'])
+        .optional()
+        .describe('집계 단위 (기본 DAILY)'),
+      reportType: z
+        .string()
+        .optional()
+        .describe('기본 SALES. 구독 분석은 SUBSCRIPTION / SUBSCRIPTION_EVENT / SUBSCRIBER'),
+      reportSubType: z.string().optional().describe('기본 SUMMARY. 상세는 DETAILED'),
+      version: z
+        .string()
+        .optional()
+        .describe('리포트 버전 (기본 1_0). SUBSCRIPTION 계열은 1_3 등 다른 버전을 요구할 수 있다'),
+      vendorNumber: z
+        .string()
+        .optional()
+        .describe('판매자 번호. 생략 시 ~/.mimi-seed/appstore.json 의 vendorNumber 사용'),
+    },
+    async (args) => jsonResult(await appstoreSales.getSalesReport(args)),
+  );
+
+  server.tool(
+    'appstore_get_finance_report',
+    [
+      '재무(정산) 리포트 — GET /v1/financeReports. 실제로 지급되는 금액 기준이라',
+      'Sales and Trends(판매 시점 집계)와 숫자가 다를 수 있다.',
+      '⚠️ **reportDate 는 Apple 회계월이다** — 달력월과 어긋난다(회계연도가 9월 말에 시작).',
+      '요청한 달과 다른 기간이 돌아오면 버그가 아니라 이것이다. 매출 건수를 세는 목적이면',
+      'appstore_get_sales_report(달력 날짜 기준)를 쓰는 편이 낫다.',
+      'regionCode 는 ZZ(전 지역 통합)가 기본이고, FINANCE_DETAIL 은 보통 Z1 을 쓴다.',
+      '컬럼 구성이 리포트마다 달라 파싱한 행을 그대로 돌려준다.',
+    ].join(' '),
+    {
+      reportDate: z.string().describe('YYYY-MM (Apple 회계월)'),
+      regionCode: z.string().optional().describe('지역 코드 (기본 ZZ = 전 지역 통합)'),
+      reportType: z
+        .enum(['FINANCIAL', 'FINANCE_DETAIL'])
+        .optional()
+        .describe('기본 FINANCIAL'),
+      vendorNumber: z
+        .string()
+        .optional()
+        .describe('판매자 번호. 생략 시 ~/.mimi-seed/appstore.json 의 vendorNumber 사용'),
+    },
+    async (args) => jsonResult(await appstoreSales.getFinanceReport(args)),
   );
 }

--- a/packages/mcp-server/src/registers/playstore.ts
+++ b/packages/mcp-server/src/registers/playstore.ts
@@ -15,6 +15,7 @@ import {
 } from '@onesub/providers';
 import { requirePlayStoreAuth, requireServiceAccountJson, requireAuth } from '../helpers.js';
 import { PLAY_DEVELOPER_REPORTING_SCOPE } from '../auth/scopes.js';
+import * as playFinancials from '../playstore/financials.js';
 import * as iam from '../iam/tools.js';
 import { buildPlayStoreReleasePlan } from '../checks/plan.js';
 import { validatePlayReleaseNotes, formatIssuesForUser } from '../lib/text-validators.js';
@@ -1146,5 +1147,58 @@ export function registerPlaystoreTools(server: McpServer) {
       const r = await playstore.cancelRecoveryAction(auth, packageName, appRecoveryId);
       return textResult(`✅ 복구 액션 취소 — ${r.appRecoveryId}`);
     },
+  );
+
+  server.tool(
+    'playstore_list_financial_reports',
+    [
+      'Play 재무 리포트 파일 목록 (Cloud Storage 버킷).',
+      '⚠️ **Play Developer API 에는 매출 엔드포인트가 없다.** purchases.* 는 구매 토큰을 이미 알아야 하고',
+      'Reporting API 는 vitals 뿐이다. 실제 정산 데이터는 Play Console 이 매달 개발자 소유 GCS 버킷에',
+      '떨궈주는 CSV 가 유일한 소스라, 이 도구는 그 버킷을 훑는다.',
+      '버킷 이름(gs://pubsite_prod_...)은 Play Console > 다운로드 보고서 > 재무 에만 있고 API 로 못 얻는다 —',
+      '~/.mimi-seed/play-financials.json 에 한 번 저장해두면 이후 생략 가능.',
+      '⚠️ 접근 권한은 **GCP IAM 이 아니다.** 이 버킷은 Google 소유라 프로젝트에 roles/storage.* 를 줘도 닿지 않는다 —',
+      'Play Console > 사용자 및 권한 에서 서비스 계정 이메일을 초대하고 "재무 데이터 보기"를 전체(Global)로 줘야 열린다.',
+      '앱 게시용 Play Developer API 권한과 별개라, 릴리스가 되는 계정이라고 리포트가 열려 있지는 않다.',
+      '재무 리포트는 월 마감 후에 올라오므로 이번 달 파일이 없는 것은 정상이다.',
+    ].join(' '),
+    {
+      packageName: z.string().optional().describe('패키지명 — 패키지별 서비스 계정·버킷 설정을 고를 때 사용'),
+      bucket: z.string().optional().describe('버킷 이름 또는 gs:// URI. 생략 시 저장된 설정 사용'),
+      reportType: z
+        .enum(['earnings', 'sales'])
+        .optional()
+        .describe('생략하면 버킷 전체. earnings=정산(수수료·세금 포함), sales=주문 단위'),
+    },
+    async (args) => jsonResult(await playFinancials.listFinancialReports(args)),
+  );
+
+  server.tool(
+    'playstore_get_financial_report',
+    [
+      'Play 재무 리포트를 내려받아 파싱·집계한다 = **Play 실매출의 기준선**.',
+      '분석 이벤트로는 라이선스 테스터·내부 테스트 결제를 실결제와 구분할 수 없다',
+      '(둘 다 install_source 가 com.android.vending 이다). 청구가 0원인 테스터 주문은',
+      '이 리포트에 **아예 나타나지 않으므로**, 여기 없으면 실매출이 아니다.',
+      'earnings: Transaction Type 이 Charge/Google fee/Tax/환불로 나뉘고 수수료·세금이 음수로 들어와',
+      'netByMerchantCurrency 는 이미 순액이다. **Charge 행만이 실제 구매다.**',
+      'sales: 주문 번호 단위라 개별 주문을 짚을 때 쓴다.',
+      '⚠️ 정산 통화마다 파일이 따로 떨어지므로 한 달치가 여러 파일일 수 있다 — 전부 합쳐서 집계한다.',
+    ].join(' '),
+    {
+      yearMonth: z.string().describe('YYYYMM 또는 YYYY-MM'),
+      packageName: z.string().optional().describe('패키지명 — 패키지별 서비스 계정·버킷 설정을 고를 때 사용'),
+      bucket: z.string().optional().describe('버킷 이름 또는 gs:// URI. 생략 시 저장된 설정 사용'),
+      reportType: z
+        .enum(['earnings', 'sales'])
+        .optional()
+        .describe('기본 earnings(정산). 주문 단위로 보려면 sales'),
+      includeRows: z
+        .boolean()
+        .optional()
+        .describe('원본 행까지 전부 반환. 건수가 많으면 응답이 매우 커진다'),
+    },
+    async (args) => jsonResult(await playFinancials.getFinancialReport(args)),
   );
 }

--- a/packages/mcp-server/tool-manifest.json
+++ b/packages/mcp-server/tool-manifest.json
@@ -1,6 +1,6 @@
 {
   "$comment": "등록된 MCP 도구 + 도메인 메타데이터(label·credential·summary)의 SSOT. src/__tests__/tool-manifest.test.ts 가 실제 서버 등록 목록과 diff 하고 메타데이터 정합성을 검사한다. 도구 추가/삭제/개명 시 이 파일을 함께 갱신할 것 — 산문 문서에는 정확한 개수를 쓰지 말고 이 파일을 가리킬 것. mimi-seed://tools/catalog 리소스가 이 파일을 그대로 서빙한다.",
-  "total": 226,
+  "total": 230,
   "domains": {
     "admob": {
       "label": "AdMob",
@@ -38,7 +38,7 @@
     "appstore": {
       "label": "App Store Connect",
       "credential": "ASC API 키 (mimi-seed auth appstore)",
-      "summary": "버전·빌드 attach·What's New·스크린샷·IAP 심사 메타데이터·심사 제출",
+      "summary": "버전·빌드 attach·What's New·스크린샷·IAP 심사 메타데이터·심사 제출·매출/재무 리포트",
       "tools": [
         "appstore_list_apps",
         "appstore_verify_credentials",
@@ -100,7 +100,9 @@
         "appstore_notify_beta_testers",
         "appstore_list_previews",
         "appstore_upload_preview",
-        "appstore_delete_preview"
+        "appstore_delete_preview",
+        "appstore_get_sales_report",
+        "appstore_get_finance_report"
       ]
     },
     "auth": {
@@ -285,7 +287,7 @@
     "playstore": {
       "label": "Google Play",
       "credential": "Google OAuth (CI/헤드리스는 Play 서비스 계정)",
-      "summary": "리스팅·트랙 릴리스·이미지·리뷰 답변·통계·서비스 계정 등록",
+      "summary": "리스팅·트랙 릴리스·이미지·리뷰 답변·통계·서비스 계정 등록·재무 리포트",
       "tools": [
         "playstore_get_app",
         "playstore_update_details",
@@ -323,7 +325,9 @@
         "playstore_list_recovery_actions",
         "playstore_create_recovery_action",
         "playstore_deploy_recovery_action",
-        "playstore_cancel_recovery_action"
+        "playstore_cancel_recovery_action",
+        "playstore_list_financial_reports",
+        "playstore_get_financial_report"
       ]
     },
     "threads": {

--- a/plugins/mimi-seed/.codex-plugin/plugin.json
+++ b/plugins/mimi-seed/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/plugins/mimi-seed/docs/agent-guide.md
+++ b/plugins/mimi-seed/docs/agent-guide.md
@@ -70,6 +70,7 @@ you can paste. Pick the row for the job; batching two rows in one `select:` call
 | Analytics wiring (Firebase ↔ GA4 ↔ BigQuery) | `select:firebase_link_analytics,firebase_get_analytics_details,ga4_list_account_summaries,ga4_list_properties,ga4_create_property,ga4_list_data_streams,ga4_create_data_stream,ga4_plan_bigquery_link,ga4_create_bigquery_link,ga4_run_report` |
 | BigQuery | `select:bigquery_auth_status,bigquery_list_datasets,bigquery_list_tables,bigquery_get_table_schema,bigquery_run_query` |
 | GCP billing (Blaze 여부 · 비용 범위 · 예산) | `select:gcp_get_billing_info,gcp_list_billing_projects,gcp_list_budgets,gcp_create_budget` |
+| Real revenue (스토어 정산 원장 — sandbox·테스터가 섞이지 않는 유일한 창구) | `select:appstore_get_sales_report,appstore_get_finance_report,playstore_list_financial_reports,playstore_get_financial_report` |
 | AdMob | `select:admob_list_accounts,admob_list_apps,admob_create_app,admob_create_ad_unit,admob_list_ad_units,admob_get_today_earnings,admob_get_report` |
 | Google Ads (UAC) | `select:googleads_config_status,googleads_save_config,googleads_list_accessible_customers,googleads_list_campaigns,googleads_get_campaign_report,googleads_get_uac_report` |
 | Search Console | `select:gsc_list_sites,gsc_list_sitemaps,gsc_get_sitemap,gsc_submit_sitemap,gsc_inspect_url,gsc_search_analytics` |

--- a/plugins/mimi-seed/docs/domain/tool-catalog.md
+++ b/plugins/mimi-seed/docs/domain/tool-catalog.md
@@ -1,4 +1,4 @@
-# Tool catalog — 226 tools across 21 domains
+# Tool catalog — 230 tools across 21 domains
 
 > The MCP server's "entities". One row per domain → register file → tools, with **W** (write) and **D**
 > (destructive / near-irreversible) markers. Everything unmarked is read-only.
@@ -11,8 +11,8 @@
 
 | Domain | Register file | Tools |
 |--------|---------------|------:|
-| App Store Connect | `registers/appstore.ts` | 61 |
-| Google Play | `registers/playstore.ts` | 37 |
+| App Store Connect | `registers/appstore.ts` | 63 |
+| Google Play | `registers/playstore.ts` | 39 |
 | Firebase | `registers/firebase.ts` | 20 |
 | AdMob | `registers/admob.ts` | 7 |
 | CI (GitHub/GitLab) | `registers/ci.ts` | 6 |
@@ -32,14 +32,15 @@
 | Android signing | `registers/android.ts` | 3 |
 | AI | `registers/ai.ts` | 2 |
 | Video production | `registers/video.ts` | 14 |
-| **Total** | **21 modules** | **226** |
+| **Total** | **21 modules** | **230** |
 
-## Google Play — `registers/playstore.ts` (37) · impl `playstore/tools.ts`
+## Google Play — `registers/playstore.ts` (39) · impl `playstore/tools.ts`
 
 - Read: `playstore_list_recovery_actions` · `playstore_get_app` · `playstore_get_listing` · `playstore_list_tracks` · `playstore_get_statistics` ·
   `playstore_list_images` · `playstore_list_reviews` · `playstore_list_inapp_products` ·
   `playstore_list_subscriptions` · `playstore_list_products` · `playstore_list_service_accounts` ·
-  `playstore_verify_service_account` · `playstore_plan_release`
+  `playstore_verify_service_account` · `playstore_plan_release` ·
+  `playstore_list_financial_reports` · `playstore_get_financial_report` (GCS 재무 CSV — Play API 엔 매출 엔드포인트가 없다)
 - **W** `playstore_create_recovery_action` (DRAFT 생성 — 아직 사용자에게 안 나감) ·
   `playstore_upload_data_safety` (데이터 안전 CSV — 기존 제출 전체 덮어씀, confirm 게이트) ·
   `playstore_update_listing` · `playstore_update_details` (developer contact + default language —
@@ -53,7 +54,7 @@
   `playstore_cancel_recovery_action` · `playstore_submit_release` · `playstore_promote_release` · `playstore_delete_all_images` ·
   `playstore_delete_product` · `playstore_delete_service_account`
 
-## App Store Connect — `registers/appstore.ts` (61) · impl `appstore/tools.ts`
+## App Store Connect — `registers/appstore.ts` (63) · impl `appstore/tools.ts`
 
 - Read: `appstore_list_apps` · `appstore_verify_credentials` · `appstore_get_app` · `appstore_list_versions` ·
   `appstore_get_metadata` · `appstore_list_screenshots` · `appstore_get_review_notes` · `appstore_list_builds` ·
@@ -75,6 +76,8 @@
   `appstore_update_product_review_note` · `appstore_update_product_localization` ·
   `appstore_add_product_to_review` ·
   `appstore_upload_product_review_screenshot`
+- Read(매출): `appstore_get_sales_report` (Sales and Trends — sandbox 가 섞이지 않는 실매출 기준선) ·
+  `appstore_get_finance_report` (정산 — reportDate 는 **Apple 회계월**)
 - **U** `appstore_update_version_string` · `appstore_add_version_to_review_submission` ·
   `appstore_update_release_type` (MANUAL / AFTER_APPROVAL / SCHEDULED 전환) ·
   `appstore_phased_release` (단계적 출시 — `enable`/`pause`/`resume`은 되돌릴 수 있음)


### PR DESCRIPTION
분석 이벤트로는 실매출을 셀 수 없다. TestFlight·Xcode 설치의 iOS 결제는 **sandbox 라 청구가 0원인데도** 클라이언트엔 성공한 결제로 보여 이벤트가 그대로 나가고, Android 는 라이선스 테스터와 실구매자가 **둘 다 `install_source=com.android.vending`** 이라 구분이 안 된다. 애초에 그것들이 들어오지 않는 창구가 필요해서 스토어 정산 원장을 읽는 도구를 넣었다.

## 추가 도구 (226 → 230)

**App Store Connect** — `appstore/sales.ts`

| 도구 | 엔드포인트 |
|---|---|
| `appstore_get_sales_report` | `GET /v1/salesReports` (gzip TSV 파싱·집계) |
| `appstore_get_finance_report` | `GET /v1/financeReports` |

이 둘만 JSON 이 아니라 gzip TSV 라 `appstore/http.ts` 의 `apiRequest` 를 못 쓴다 → 별도 모듈. `vendorNumber` 는 API 로 조회할 방법이 없어 `~/.mimi-seed/appstore.json` 에 저장(선택 필드)하고 인자로 덮어쓸 수 있다.

**Google Play** — `playstore/financials.ts`

| 도구 | 소스 |
|---|---|
| `playstore_list_financial_reports` | GCS 버킷 객체 목록 |
| `playstore_get_financial_report` | earnings/sales ZIP → CSV 파싱·집계 |

**Play Developer API 에는 매출 엔드포인트 자체가 없다.** `purchases.*` 는 구매 토큰을 이미 알아야 하고 Reporting API 는 vitals 뿐이라, Play Console 이 매달 개발자 소유 GCS 버킷에 떨궈주는 CSV 가 유일한 소스다.

Node 에 zip 해제가 없어 최소 ZIP 리더(stored/deflate)와 CSV 파서를 직접 넣었다 — 이거 하나 때문에 의존성을 늘리지 않는다. 실제 ZIP 픽스처로 검증했고 따옴표 안 쉼표까지 보존된다.

## 실데이터로 잡은 함정들 (도구 설명·에러 문구에 반영)

- **Developer Proceeds 는 1개당 금액**이다. 그냥 합치면 매출이 통째로 틀린다 — 도구가 units 를 곱해서 준다.
- **환불은 units 음수**로 들어와 상쇄된다 → 합계가 곧 순매출.
- 데이터 없는 날짜에 Apple 은 **404** 를 준다. 인증 실패·잘못된 vendorNumber 도 같은 404 라 "매출 0"과 "설정 오류"가 섞인다 → `datesWithoutData` 로 분리하고, `vendorNumber`·`bucket` 누락은 요청을 보내기 **전에** 끊는다.
- `financeReports` 의 `reportDate` 는 **Apple 회계월**이라 달력월과 어긋난다.
- **Play 재무 버킷 접근은 GCP IAM 이 아니다.** `pubsite_prod_*` 는 Google 소유라 프로젝트에 `roles/storage.*` 를 줘도 닿지 않는다 — Play Console 사용자 권한("재무 데이터 보기" **전체**)으로만 열린다. 403 안내가 이 절차를 그대로 출력한다.
- **GCS 목록은 페이지를 끝까지 돌아야 한다.** 버킷에 `stats/` 하위 CSV 가 수천 개라 첫 페이지만 읽으면 `earnings/`·`sales/` 가 **통째로 안 보이는데 응답은 성공**이라, "그 달 리포트가 없다"는 오답으로 조용히 둔갑한다. 실제로 처음 돌렸을 때 이 증상이 났다.
- 컬럼명이 리포트마다 다르다 — earnings 는 `Product id`, sales 는 **`SKU ID`**(전부 대문자). 빠뜨리면 상품별 집계가 빈 키로 뭉개진다.
- 상품별 집계를 **통화별로 가른다.** IDR 1,003,440 과 KRW 17,600 을 한 숫자로 더하면 아무 의미 없는 값이 된다.

Play GCS 용 JWT 는 기존 Play SA 클라이언트와 **분리**했다 — 그쪽은 모든 Play 도구가 공유하는 경로라, 리포트 하나 때문에 storage 스코프를 얹으면 실패 범위가 도구 전체로 번진다.

## 검증

- `npm test` **556 passed** (`manifest-schema-parity` 는 `new URL('C:/...')` Windows 전용 경로 버그로 로컬만 실패 — CI 통과, 기존 이슈)
- `npm run plugin:check` 통과 (agent-guide · codex plugin · versions 0.17.0)
- manifest 230 ↔ 서버 실제 등록 diff 통과
- 실제 버킷·실제 리포트로 end-to-end 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)