### PR TITLE
fix(mcp): 매출 리포트 403 을 진단 가능하게 — 리포트 전용 롤 요구를 사전에 알린다 (0.17.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed",
   "displayName": "Mimi Seed",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube 게시를 Claude Code에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed-sdk",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Monorepo root — the SDK version (SSOT for both packages and client plugin manifests) plus bootstrap scripts. The publishable packages live in packages/. This is NOT an npm workspace: each package installs independently.",
   "type": "module",
   "engines": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Mimi Seed CLI \u2014 Claude Code\uc640 Codex\uc5d0\uc11c \uc571 \ucd9c\uc2dc \uc6b4\uc601\uc744 \uad00\ub9ac\ud569\ub2c8\ub2e4.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Mimi Seed MCP server \u2014 Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/appstore/sales.ts
+++ b/packages/mcp-server/src/appstore/sales.ts
@@ -61,6 +61,28 @@ async function fetchReport(
   });
 
   if (response.status === 404) return { notFound: true, rows: [], raw: '' };
+  if (response.status === 403) {
+    // 일반 403 안내("키 role 확인")로는 못 고친다 — 리포트 엔드포인트만 요구 롤이 다르다.
+    // 앱 메타데이터가 멀쩡히 조회되는 키에서도 여기서만 막히는 게 정상 동작이라,
+    // "키가 깨졌나" 로 헤매기 쉽다.
+    throw new Error(
+      [
+        '❌ 매출 리포트 접근 거부 (403) — 키는 정상인데 **롤이 부족**하다.',
+        '',
+        '리포트 엔드포인트는 다른 App Store Connect API 와 요구 롤이 다르다:',
+        '  필요: **Admin / Finance / Sales and Reports(ACCESS_TO_REPORTS)** 중 하나',
+        'App Manager·Developer 키는 앱 메타데이터는 다 되는데 여기서만 막힌다 —',
+        '다른 도구가 잘 도는 것은 이 403 과 아무 관계가 없다.',
+        '',
+        'App Store Connect > 사용자 및 액세스 > 통합 > App Store Connect API 에서',
+        '해당 키의 액세스 권한을 확인할 것. 키의 롤은 나중에 못 바꾸는 경우가 있으니,',
+        '그때는 위 롤로 **새 키를 발급**하고 다시 등록한다:',
+        '  npx -p @yoonion/mimi-seed-mcp mimi-seed-appstore-auth',
+        '',
+        '⚠️ 이 키를 바꾸면 배포 파이프라인이 같은 키를 쓰는지도 함께 확인할 것.',
+      ].join('\n'),
+    );
+  }
   if (!response.ok) {
     throw friendlyAppStoreError(response.status, await response.text());
   }
@@ -234,6 +256,54 @@ export async function getSalesReport(
   }
 
   return { datesWithData, datesWithoutData, lines, proceedsByCurrency, paidUnits, freeUnits };
+}
+
+/**
+ * 리포트 접근 가능 여부만 싸게 확인한다 (appstore_verify_credentials 용).
+ *
+ * 왜 별도 프로브가 필요한가: 리포트 엔드포인트는 **다른 ASC API 와 요구 롤이 다르다.**
+ * App Manager 키는 GET /apps 가 멀쩡히 되므로 기존 검증은 전부 통과하는데, 매출 도구만
+ * 403 으로 죽는다. 그 사실이 첫 매출 조회 때까지 드러나지 않으면 "도구가 고장났다" 로
+ * 오진하게 된다 — Play 쪽 playstore_verify_service_account 가 'View financial data' 를
+ * 함께 확인하는 것과 같은 이유다.
+ */
+export async function probeReportsAccess(): Promise<{
+  status: 'ok' | 'no_vendor_number' | 'forbidden' | 'error';
+  detail: string;
+}> {
+  let vendorNumber: string;
+  try {
+    vendorNumber = resolveVendorNumber();
+  } catch {
+    return {
+      status: 'no_vendor_number',
+      detail: 'vendorNumber 미설정 — ~/.mimi-seed/appstore.json 에 추가하면 매출 리포트를 쓸 수 있다.',
+    };
+  }
+
+  // 어제 날짜 하루치. 데이터가 없어 404 여도 **권한 확인 목적은 달성**된다 —
+  // 403 이 아니라는 것 자체가 롤이 충분하다는 뜻이다.
+  const probeDate = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+  try {
+    await fetchReport('/salesReports', {
+      'filter[frequency]': 'DAILY',
+      'filter[reportType]': 'SALES',
+      'filter[reportSubType]': 'SUMMARY',
+      'filter[vendorNumber]': vendorNumber,
+      'filter[reportDate]': probeDate,
+      'filter[version]': '1_0',
+    });
+    return { status: 'ok', detail: `매출 리포트 접근 가능 (vendorNumber ${vendorNumber})` };
+  } catch (err) {
+    const message = (err as Error)?.message ?? '';
+    if (message.includes('403')) {
+      return {
+        status: 'forbidden',
+        detail: '매출 리포트 403 — 키 롤 부족 (Admin / Finance / Sales and Reports 필요)',
+      };
+    }
+    return { status: 'error', detail: message.split('\n')[0] };
+  }
 }
 
 export async function getFinanceReport(options: {

--- a/packages/mcp-server/src/registers/appstore.ts
+++ b/packages/mcp-server/src/registers/appstore.ts
@@ -37,11 +37,20 @@ export function registerAppstoreTools(server: McpServer) {
 
   server.tool(
     'appstore_verify_credentials',
-    'App Store Connect API 키(appstore.json) 유효성 검증 — JWT 서명 + GET /apps 호출로 creds/sign/auth/api 단계별 진단. 첫 도구 호출에서 401로 늦게 터지기 전에 setup 직후 확인용. 인자 없음.',
+    [
+      'App Store Connect API 키(appstore.json) 유효성 검증 — JWT 서명 + GET /apps 호출로',
+      'creds/sign/auth/api 단계별 진단. 첫 도구 호출에서 401로 늦게 터지기 전에 setup 직후 확인용.',
+      '매출 리포트 접근 가능 여부도 함께 확인한다 — 그쪽만 요구 롤이 달라서',
+      '(Admin/Finance/Sales and Reports) 앱 메타데이터는 다 되는데 매출만 403 인 키가 흔하다.',
+      '인자 없음.',
+    ].join(' '),
     {},
     async () => {
       const r = await appstore.verifyAppStoreCredentials();
       if (r.ok) {
+        // 키가 유효할 때만 물어본다 — 인증 자체가 깨졌으면 403/401 구분이 무의미하다.
+        const reports = await appstoreSales.probeReportsAccess();
+        const reportsIcon = reports.status === 'ok' ? '✓' : reports.status === 'forbidden' ? '✗' : '·';
         return {
           content: [{
             type: 'text',
@@ -49,6 +58,10 @@ export function registerAppstoreTools(server: McpServer) {
               '✓ App Store Connect 인증 유효',
               r.appCount != null ? `   접근 가능 앱: ${r.appCount}개` : '',
               r.firstApp ? `   예: ${r.firstApp.name ?? r.firstApp.id}` : '',
+              `${reportsIcon} 매출 리포트: ${reports.detail}`,
+              reports.status === 'forbidden'
+                ? '   → 키 롤은 나중에 못 바꾸는 경우가 있다. 그때는 위 롤로 새 키를 발급해 다시 등록할 것.'
+                : '',
             ].filter(Boolean).join('\n'),
           }],
         };

--- a/plugins/mimi-seed/.codex-plugin/plugin.json
+++ b/plugins/mimi-seed/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",


### PR DESCRIPTION
0.17.0 의 매출 도구를 **실제 키로 처음 돌렸더니 403** 이 났다. 그런데 같은 키로 `GET /apps` 는 앱 10개가 멀쩡히 조회된다 — 리포트 엔드포인트만 요구 롤이 다르기 때문이다(**Admin / Finance / Sales and Reports**).

기존 안내는 "키 role 확인" 한 줄뿐이라 어느 롤이 왜 필요한지 알 수 없고, 다른 도구가 잘 도니까 **"새로 넣은 도구가 고장났다"로 오진하기 쉽다.**

## 변경

- `salesReports`/`financeReports` 403 을 **전용 메시지로 분기.** 필요한 롤을 이름으로 적고, "다른 도구가 되는 것은 이 403 과 무관하다"를 명시한다. 키 롤은 나중에 못 바꾸는 경우가 있어 새 키 발급 경로까지 안내한다.
- `probeReportsAccess()` 신설 + **`appstore_verify_credentials` 에 연결.** 어제 날짜 하루치를 찔러보고 403 인지만 본다 — 데이터가 없어 404 여도 권한 확인 목적은 달성된다(403 이 아니라는 것 자체가 롤이 충분하다는 뜻).

  Play 쪽 `playstore_verify_service_account` 가 `View financial data` 를 함께 확인하는 것과 같은 이유다. 이게 없으면 **롤 부족이 첫 매출 조회 때까지 드러나지 않는다.**

Apple 은 API 키의 롤을 조회·변경하는 공개 API 를 제공하지 않는다 — 자동 교정은 불가능하고, 할 수 있는 건 "무엇을 어디서 고쳐야 하는지"를 정확히 말해주는 것뿐이다.

## 검증

실제 키로 확인:
```
{ "status": "forbidden",
  "detail": "매출 리포트 403 — 키 롤 부족 (Admin / Finance / Sales and Reports 필요)" }
```

`npm test` 556 passed · `plugin:check` 0.17.1 통과 · 도구 개수 변화 없음(230)이라 manifest·문서 갱신 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)