### PR TITLE
feat(mcp): 매출 리포트 전용 키(reportsKey) 분리 — 배포 키를 건드리지 않고 롤 문제를 푼다 (0.18.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed",
   "displayName": "Mimi Seed",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube 게시를 Claude Code에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed-sdk",
   "private": true,
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Monorepo root — the SDK version (SSOT for both packages and client plugin manifests) plus bootstrap scripts. The publishable packages live in packages/. This is NOT an npm workspace: each package installs independently.",
   "type": "module",
   "engines": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Mimi Seed CLI \u2014 Claude Code\uc640 Codex\uc5d0\uc11c \uc571 \ucd9c\uc2dc \uc6b4\uc601\uc744 \uad00\ub9ac\ud569\ub2c8\ub2e4.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Mimi Seed MCP server \u2014 Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/appstore/auth.ts
+++ b/packages/mcp-server/src/appstore/auth.ts
@@ -21,6 +21,29 @@ export interface AppStoreCredentials {
    * 여기 적어두는 수밖에 없다. 리포트 도구에만 쓰이므로 없어도 나머지는 다 동작한다.
    */
   vendorNumber?: string;
+
+  /**
+   * 매출 리포트 전용 별도 키 (선택).
+   *
+   * 리포트 엔드포인트는 다른 ASC API 와 요구 롤이 다르다 —
+   * **Admin / Finance / Sales and Reports** 중 하나여야 한다. 배포에 쓰는 키는 보통
+   * App Manager 라 여기서만 403 이 나는데, **Apple 은 발급된 키의 롤을 수정할 수 없게**
+   * 해놨다(폐기 후 재발급만 가능).
+   *
+   * 그렇다고 배포 키를 Admin 으로 갈아끼우면 잘 돌던 릴리스 파이프라인의 자격증명을
+   * 전부 교체해야 하고, 권한도 사용자·재무까지 넓어진다. 그래서 **읽기 전용 Finance 키를
+   * 따로 두고 리포트 도구만 이걸 쓰게** 한다. 배포 키는 손대지 않는다.
+   *
+   * 없으면 최상위 키로 폴백하므로, 배포 키가 이미 Admin 이면 설정할 필요가 없다.
+   */
+  reportsKey?: AppStoreKey;
+}
+
+/** ASC API 키 한 벌. 최상위 자격증명과 reportsKey 가 같은 모양을 공유한다. */
+export interface AppStoreKey {
+  issuerId: string;
+  keyId: string;
+  privateKey: string;
 }
 
 export function getAppStoreCredentials(): AppStoreCredentials | null {
@@ -82,4 +105,27 @@ export async function getAuthHeaders(): Promise<Record<string, string> | null> {
   if (!creds) return null;
   const token = await generateToken(creds);
   return { Authorization: `Bearer ${token}` };
+}
+
+/**
+ * 매출 리포트용 헤더 — reportsKey 가 있으면 그걸로, 없으면 최상위 키로 폴백.
+ *
+ * 폴백이 조용하면 안 된다: 403 이 났을 때 "어느 키가 거부당했는지" 를 모르면 사용자가
+ * 엉뚱한 키의 롤을 들여다보게 된다. 그래서 어느 키를 썼는지 함께 돌려준다.
+ */
+export async function getReportsAuthHeaders(): Promise<
+  { headers: Record<string, string>; source: 'reportsKey' | 'default' } | null
+> {
+  const creds = getAppStoreCredentials();
+  if (!creds) return null;
+  if (creds.reportsKey) {
+    return {
+      headers: { Authorization: `Bearer ${await generateToken(creds.reportsKey)}` },
+      source: 'reportsKey',
+    };
+  }
+  return {
+    headers: { Authorization: `Bearer ${await generateToken(creds)}` },
+    source: 'default',
+  };
 }

--- a/packages/mcp-server/src/appstore/sales.ts
+++ b/packages/mcp-server/src/appstore/sales.ts
@@ -10,9 +10,9 @@
 
 import zlib from 'node:zlib';
 import { fetchWithTimeout } from '../lib/http.js';
-import { getAppStoreCredentials } from './auth.js';
+import { getAppStoreCredentials, getReportsAuthHeaders } from './auth.js';
 import { friendlyAppStoreError } from './errors.js';
-import { authHeadersOrThrow, V1_BASE } from './http.js';
+import { V1_BASE } from './http.js';
 
 /**
  * vendorNumber 해석: 명시 인자 > ~/.mimi-seed/appstore.json 의 vendorNumber.
@@ -54,10 +54,20 @@ async function fetchReport(
   resourcePath: string,
   params: Record<string, string>,
 ): Promise<{ notFound: boolean; rows: ReportRow[]; raw: string }> {
-  const authHeaders = await authHeadersOrThrow();
+  const auth = await getReportsAuthHeaders();
+  if (!auth) {
+    throw new Error(
+      [
+        '❌ App Store Connect 인증이 필요해.',
+        '',
+        '터미널에서 실행:',
+        '  npx -p @yoonion/mimi-seed-mcp mimi-seed-appstore-auth',
+      ].join('\n'),
+    );
+  }
   const query = new URLSearchParams(params).toString();
   const response = await fetchWithTimeout(`${V1_BASE}${resourcePath}?${query}`, {
-    headers: { ...authHeaders, Accept: 'application/a-gzip' },
+    headers: { ...auth.headers, Accept: 'application/a-gzip' },
   });
 
   if (response.status === 404) return { notFound: true, rows: [], raw: '' };
@@ -68,18 +78,21 @@ async function fetchReport(
     throw new Error(
       [
         '❌ 매출 리포트 접근 거부 (403) — 키는 정상인데 **롤이 부족**하다.',
+        `   거부당한 키: ${auth.source === 'reportsKey' ? 'reportsKey (리포트 전용)' : '최상위 키 (배포용과 동일)'}`,
         '',
         '리포트 엔드포인트는 다른 App Store Connect API 와 요구 롤이 다르다:',
         '  필요: **Admin / Finance / Sales and Reports(ACCESS_TO_REPORTS)** 중 하나',
         'App Manager·Developer 키는 앱 메타데이터는 다 되는데 여기서만 막힌다 —',
         '다른 도구가 잘 도는 것은 이 403 과 아무 관계가 없다.',
         '',
-        'App Store Connect > 사용자 및 액세스 > 통합 > App Store Connect API 에서',
-        '해당 키의 액세스 권한을 확인할 것. 키의 롤은 나중에 못 바꾸는 경우가 있으니,',
-        '그때는 위 롤로 **새 키를 발급**하고 다시 등록한다:',
-        '  npx -p @yoonion/mimi-seed-mcp mimi-seed-appstore-auth',
+        '⚠️ **발급된 키의 롤은 수정할 수 없다** (Apple 정책 — 폐기 후 재발급만 가능).',
+        '그렇다고 배포 키를 갈아끼우면 릴리스 파이프라인 자격증명을 전부 교체해야 한다.',
         '',
-        '⚠️ 이 키를 바꾸면 배포 파이프라인이 같은 키를 쓰는지도 함께 확인할 것.',
+        '권장: **읽기 전용 Finance 키를 따로 발급**해 리포트 도구만 쓰게 한다.',
+        '  1) ASC > 사용자 및 액세스 > 통합 > 팀 키 > 키 생성, 액세스 = Finance',
+        '  2) 받은 .p8 내용을 ~/.mimi-seed/appstore.json 의 reportsKey 에 넣는다:',
+        '     "reportsKey": { "issuerId": "...", "keyId": "...", "privateKey": "-----BEGIN..." }',
+        '배포 키는 그대로 두면 된다 — 리포트 도구만 reportsKey 를 쓴다.',
       ].join('\n'),
     );
   }
@@ -293,13 +306,24 @@ export async function probeReportsAccess(): Promise<{
       'filter[reportDate]': probeDate,
       'filter[version]': '1_0',
     });
-    return { status: 'ok', detail: `매출 리포트 접근 가능 (vendorNumber ${vendorNumber})` };
+    const usingSeparateKey = getAppStoreCredentials()?.reportsKey != null;
+    return {
+      status: 'ok',
+      detail:
+        `매출 리포트 접근 가능 (vendorNumber ${vendorNumber}, ` +
+        `${usingSeparateKey ? 'reportsKey 사용' : '최상위 키 사용'})`,
+    };
   } catch (err) {
     const message = (err as Error)?.message ?? '';
     if (message.includes('403')) {
+      const usingSeparateKey = getAppStoreCredentials()?.reportsKey != null;
       return {
         status: 'forbidden',
-        detail: '매출 리포트 403 — 키 롤 부족 (Admin / Finance / Sales and Reports 필요)',
+        detail:
+          '매출 리포트 403 — 키 롤 부족 (Admin / Finance / Sales and Reports 필요). ' +
+          (usingSeparateKey
+            ? 'reportsKey 가 거부당했다.'
+            : 'reportsKey 를 따로 두면 배포 키를 건드리지 않아도 된다.'),
       };
     }
     return { status: 'error', detail: message.split('\n')[0] };

--- a/packages/mcp-server/src/registers/appstore.ts
+++ b/packages/mcp-server/src/registers/appstore.ts
@@ -1924,6 +1924,9 @@ export function registerAppstoreTools(server: McpServer) {
       '⚠️ 데이터가 없는 날짜는 Apple 이 404 를 주므로 datesWithoutData 로 따로 돌려준다 —',
       '"매출 0" 과 "리포트 미생성/설정 오류"를 섞지 말 것. 당일치는 보통 아직 없다.',
       'vendorNumber 는 ~/.mimi-seed/appstore.json 에 저장해두면 생략 가능.',
+      '⚠️ **리포트는 요구 롤이 다르다** — Admin/Finance/Sales and Reports 중 하나여야 하고,',
+      '배포에 흔히 쓰는 App Manager 키는 여기서만 403 이 난다. 발급된 키의 롤은 수정할 수 없으므로,',
+      '읽기 전용 Finance 키를 발급해 appstore.json 의 **reportsKey** 에 넣으면 배포 키를 건드리지 않아도 된다.',
     ].join(' '),
     {
       startDate: z.string().describe('시작일 YYYY-MM-DD (DAILY 가 아니면 이 값이 곧 reportDate)'),

--- a/plugins/mimi-seed/.codex-plugin/plugin.json
+++ b/plugins/mimi-seed/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",


### PR DESCRIPTION
리포트 엔드포인트는 다른 ASC API 와 **요구 롤이 다르다**(Admin / Finance / Sales and Reports). 배포에 흔히 쓰는 App Manager 키는 앱 메타데이터·빌드·심사 제출이 전부 되는데 매출 리포트에서만 403 이 난다.

그런데 **Apple 은 발급된 키의 롤을 수정할 수 없게 해놨다** — 폐기 후 재발급만 가능하다.

배포 키를 Admin 으로 갈아끼우는 건 대가가 크다:
- 잘 돌던 릴리스 파이프라인의 자격증명을 전부 교체해야 한다 (순서를 틀리면 릴리스가 멈춘다)
- 권한이 사용자·재무까지 넓어진다

→ **읽기 전용 Finance 키를 따로 두고 리포트 도구만 그걸 쓰게 한다.**

## 변경

- `AppStoreCredentials.reportsKey` (선택) 추가 + `AppStoreKey` 타입 분리
- `getReportsAuthHeaders()`: `reportsKey` 있으면 그걸로, 없으면 최상위 키로 폴백.
  **어느 키를 썼는지 함께 돌려준다** — 폴백이 조용하면 403 때 사용자가 엉뚱한 키의 롤을 들여다보게 된다.
- 403 안내가 **거부당한 키를 지목**하고 `reportsKey` 설정 절차를 그대로 출력
- `probeReportsAccess` / `appstore_verify_credentials` 도 어느 키를 썼는지 표시

배포 키가 이미 Admin 이면 `reportsKey` 는 설정할 필요가 없다(폴백이 그대로 동작).

## 설정

```json
// ~/.mimi-seed/appstore.json
{
  "issuerId": "...", "keyId": "...", "privateKey": "...",   // 배포용 — 그대로 둔다
  "vendorNumber": "...",
  "reportsKey": { "issuerId": "...", "keyId": "...", "privateKey": "-----BEGIN..." }
}
```

## 검증

실제 키로 폴백 경로 확인:
```
{ "status": "forbidden",
  "detail": "매출 리포트 403 — 키 롤 부족 (...). reportsKey 를 따로 두면 배포 키를 건드리지 않아도 된다." }
```

`npm test` 556 passed · `plugin:check` 0.18.0 통과 · 도구 개수 변화 없음(230)

🤖 Generated with [Claude Code](https://claude.com/claude-code)