### PR TITLE
perf(mcp): 기동 시 무거운 SDK 지연 로딩 — MCP 핸드셰이크 5.9s → 0.55s

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed",
   "displayName": "Mimi Seed",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube 게시를 Claude Code에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed-sdk",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Monorepo root — the SDK version (SSOT for both packages and client plugin manifests) plus bootstrap scripts. The publishable packages live in packages/. This is NOT an npm workspace: each package installs independently.",
   "type": "module",
   "engines": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Mimi Seed CLI \u2014 Claude Code\uc640 Codex\uc5d0\uc11c \uc571 \ucd9c\uc2dc \uc6b4\uc601\uc744 \uad00\ub9ac\ud569\ub2c8\ub2e4.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Mimi Seed MCP server \u2014 Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/appstore/auth.ts
+++ b/packages/mcp-server/src/appstore/auth.ts
@@ -1,4 +1,6 @@
-import { SignJWT, importPKCS8 } from 'jose';
+// jose 는 값 import 하지 않는다 — import 만으로 ~0.6초가 나가고, 이 파일은
+// helpers.ts 를 통해 대부분의 register 에 딸려 들어가 MCP 기동 시간을 그대로 밀어올린다.
+// 실제로 필요한 곳은 generateToken() 하나뿐이라 그 안에서 동적 import 한다.
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -79,6 +81,7 @@ function normalizePrivateKey(raw: string): string {
 }
 
 export async function generateToken(creds: AppStoreCredentials): Promise<string> {
+  const { SignJWT, importPKCS8 } = await import('jose');
   const normalizedKey = normalizePrivateKey(creds.privateKey);
   let key;
   try {

--- a/packages/mcp-server/src/auth/bigquery-auth.ts
+++ b/packages/mcp-server/src/auth/bigquery-auth.ts
@@ -1,5 +1,5 @@
-import { JWT } from 'google-auth-library';
-import type { OAuth2Client } from 'google-auth-library';
+import type { JWT, OAuth2Client } from 'google-auth-library';
+import { newJWT } from '../lib/google-auth-lite.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -68,7 +68,7 @@ export function deleteBigQueryServiceAccountJson(): boolean {
 }
 
 function makeJwt(sa: ServiceAccountKey): JWT {
-  return new JWT({ email: sa.client_email, key: sa.private_key, scopes: BQ_SCOPES });
+  return newJWT({ email: sa.client_email, key: sa.private_key, scopes: BQ_SCOPES });
 }
 
 export type BigQueryAuthSource = 'service-account' | 'user-oauth';

--- a/packages/mcp-server/src/auth/bigquery-setup-cli.ts
+++ b/packages/mcp-server/src/auth/bigquery-setup-cli.ts
@@ -6,7 +6,7 @@ import {
   getBigQueryServiceAccountKey,
 } from './bigquery-auth.js';
 import * as bigquery from '../bigquery/tools.js';
-import { JWT } from 'google-auth-library';
+import { newJWT } from '../lib/google-auth-lite.js';
 import { resolveLang } from '../lib/lang.js';
 
 // ko 가 원본이고 en 은 `typeof ko` 를 만족해야 한다 — 키를 빠뜨리면 컴파일이 깨진다.
@@ -127,7 +127,7 @@ async function main() {
   if (projectId) {
     console.log(M.probing(projectId));
     try {
-      const jwt = new JWT({
+      const jwt = newJWT({
         email: parsed.client_email,
         key: parsed.private_key,
         scopes: [

--- a/packages/mcp-server/src/auth/playstore-auth.ts
+++ b/packages/mcp-server/src/auth/playstore-auth.ts
@@ -1,4 +1,5 @@
-import { JWT } from 'google-auth-library';
+import type { JWT } from 'google-auth-library';
+import { newJWT } from '../lib/google-auth-lite.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -109,7 +110,7 @@ export function getServiceAccountClient(packageName?: string): JWT | null {
   if (!json) return null;
   try {
     const parsed = JSON.parse(json);
-    return new JWT({
+    return newJWT({
       email: parsed.client_email,
       key: parsed.private_key,
       // androidpublisher(edits/리스팅 등) + Developer Reporting(vitals 통계). 통계 도구가

--- a/packages/mcp-server/src/lib/google-auth-lite.ts
+++ b/packages/mcp-server/src/lib/google-auth-lite.ts
@@ -1,0 +1,34 @@
+/**
+ * google-auth-library 지연 로더 — googleapis-lite 와 같은 목적, 같은 기법.
+ *
+ * `import { JWT } from 'google-auth-library'` 는 그 자체로 ~0.6초다. 문제는 이게
+ * helpers.ts → 12개 register 로 전파돼, 도구를 하나도 호출하지 않아도 MCP 기동 때
+ * 무조건 지불된다는 점이다. 콜드 캐시에서는 이런 항목들이 합쳐져 기동이 25초까지 튀고,
+ * Claude Code 의 기본 5초 MCP 연결 타임아웃을 넘겨 서버가 통째로 등록되지 않는다.
+ *
+ * google-auth-library 는 `type: module` 도 `exports` 맵도 없는 순수 CJS 라
+ * `createRequire` 로 **동기** 로드가 된다. 덕분에 `getServiceAccountClient()` 처럼
+ * 이미 동기인 함수를 async 로 바꾸지 않고도 지연 로딩이 가능하다.
+ *
+ * 규칙:
+ * - `JWT` 를 **값으로** 쓰려면 이 파일의 `newJWT()` 를 쓴다.
+ * - 타입만 필요하면 `import type { JWT } from 'google-auth-library'` — 타입 import 는
+ *   런타임에 지워지므로 기동 비용이 0 이고 그대로 써도 된다.
+ * - 다른 파일에서 `import { JWT } from 'google-auth-library'` (값 import) 는 금지.
+ */
+import { createRequire } from 'node:module';
+import type { JWT, JWTOptions } from 'google-auth-library';
+
+const require = createRequire(import.meta.url);
+
+let cached: typeof import('google-auth-library') | undefined;
+
+function lib(): typeof import('google-auth-library') {
+  cached ??= require('google-auth-library') as typeof import('google-auth-library');
+  return cached;
+}
+
+/** `new JWT(opts)` 와 동일. 첫 호출에서만 google-auth-library 를 로드한다. */
+export function newJWT(opts: JWTOptions): JWT {
+  return new (lib().JWT)(opts);
+}

--- a/packages/mcp-server/src/lib/googleapis-lite.ts
+++ b/packages/mcp-server/src/lib/googleapis-lite.ts
@@ -3,43 +3,95 @@
  *
  * `import { google } from 'googleapis'` 는 import 시점에 400여 개 API 클라이언트를
  * 전부 로드해 그것만으로 ~19초를 쓴다. 그 결과 MCP 서버 기동(21~36초)이 Claude Code 의
- * MCP 연결 타임아웃(30초)을 상습 초과해, 세션에서 mimi-seed 도구가 아예 등록되지 않는
- * 사고가 났다 (2026-07-24). 실제 사용하는 API 만 서브패스로 로드하면 ~1초대다.
+ * MCP 연결 타임아웃을 상습 초과해, 세션에서 mimi-seed 도구가 아예 등록되지 않는
+ * 사고가 났다 (2026-07-24). 실제 사용하는 API 만 서브패스로 로드하면 ~1.4초대다.
  *
- * - 새 Google API 가 필요하면 여기에 import 한 줄 + google 객체에 한 줄 추가한다.
+ * 그런데 그 ~1.4초도 **기동 시점에** 전부 나갔다. 서브패스를 정적 import 하면
+ * 도구를 하나도 호출하지 않아도 googleapis 공통 런타임(google-auth-library 등)이
+ * 딸려 온다. 콜드 캐시(Windows 실시간 검사 등)에서는 이게 25초까지 튀어
+ * 기본 5초 연결 타임아웃을 다시 넘겼다 (2026-08-22).
+ *
+ * 그래서 지금은 **첫 사용 시점까지 미룬다**:
+ * - googleapis 는 `type: module` 도 `exports` 맵도 없는 순수 CJS 라
+ *   `createRequire` 로 **동기** 로드가 가능하다. 그래서 `google.admob(...)` 같은
+ *   기존 호출부를 async 로 바꿀 필요가 전혀 없다 — 소비자 코드는 그대로다.
+ * - 타입은 `typeof import(...)` 로 얻는다. 타입 위치의 import 는 런타임에 완전히
+ *   지워지므로 기동 비용이 0 이다. 절대 값 import 로 바꾸지 말 것 — 그 순간 이 파일의
+ *   존재 이유가 사라진다.
+ *
+ * 규칙:
+ * - 새 Google API 가 필요하면 아래 `google` 객체에 getter 한 줄을 추가한다.
  * - 다른 파일에서 `from 'googleapis'` 값 import 는 금지 — 반드시 이 모듈을 거친다.
- *   (googleapis 는 exports map 이 없어 서브패스 import 가 공식적으로 가능하다.)
- * - `auth` 는 AuthPlus 인스턴스라 `google.auth.OAuth2` 등 기존 사용처가 그대로 동작한다.
  */
-import { admob } from 'googleapis/build/src/apis/admob/index.js';
-import { analyticsadmin } from 'googleapis/build/src/apis/analyticsadmin/index.js';
-import { analyticsdata } from 'googleapis/build/src/apis/analyticsdata/index.js';
-import { androidpublisher } from 'googleapis/build/src/apis/androidpublisher/index.js';
-import { bigquery } from 'googleapis/build/src/apis/bigquery/index.js';
-import { billingbudgets } from 'googleapis/build/src/apis/billingbudgets/index.js';
-import { cloudbilling } from 'googleapis/build/src/apis/cloudbilling/index.js';
-import { cloudresourcemanager } from 'googleapis/build/src/apis/cloudresourcemanager/index.js';
-import { auth, firebase } from 'googleapis/build/src/apis/firebase/index.js';
-import { iam } from 'googleapis/build/src/apis/iam/index.js';
-import { searchconsole } from 'googleapis/build/src/apis/searchconsole/index.js';
-import { serviceusage } from 'googleapis/build/src/apis/serviceusage/index.js';
-import { youtube } from 'googleapis/build/src/apis/youtube/index.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+/** 서브패스 모듈 캐시 — require 자체도 캐시하지만 Map 조회가 더 싸다. */
+const cache = new Map<string, Record<string, unknown>>();
+
+/**
+ * googleapis 서브패스를 첫 호출 시점에 동기 로드한다.
+ * 첫 호출이 공통 런타임까지 함께 지불하고(~1.1초), 이후 다른 서브패스는 ~20ms 다.
+ */
+function sub(name: string): Record<string, unknown> {
+  let mod = cache.get(name);
+  if (mod === undefined) {
+    mod = require(`googleapis/build/src/apis/${name}/index.js`) as Record<string, unknown>;
+    cache.set(name, mod);
+  }
+  return mod;
+}
 
 export type { youtube_v3 } from 'googleapis/build/src/apis/youtube/index.js';
 
+/**
+ * 기존 `google.<api>(...)` 호출부와 100% 동일하게 동작하는 지연 로딩 네임스페이스.
+ * 각 프로퍼티는 getter 라서, 실제로 그 API 를 쓰는 도구가 호출될 때까지 아무것도 로드하지 않는다.
+ */
 export const google = {
-  auth,
-  admob,
-  analyticsadmin,
-  analyticsdata,
-  androidpublisher,
-  bigquery,
-  billingbudgets,
-  cloudbilling,
-  cloudresourcemanager,
-  firebase,
-  iam,
-  searchconsole,
-  serviceusage,
-  youtube,
+  // auth 는 AuthPlus 인스턴스. 어느 서브패스든 같은 걸 내보내지만,
+  // 기존 동작과 동일하게 firebase 서브패스에서 가져온다.
+  get auth(): typeof import('googleapis/build/src/apis/firebase/index.js').auth {
+    return sub('firebase').auth as typeof import('googleapis/build/src/apis/firebase/index.js').auth;
+  },
+  get admob(): typeof import('googleapis/build/src/apis/admob/index.js').admob {
+    return sub('admob').admob as typeof import('googleapis/build/src/apis/admob/index.js').admob;
+  },
+  get analyticsadmin(): typeof import('googleapis/build/src/apis/analyticsadmin/index.js').analyticsadmin {
+    return sub('analyticsadmin').analyticsadmin as typeof import('googleapis/build/src/apis/analyticsadmin/index.js').analyticsadmin;
+  },
+  get analyticsdata(): typeof import('googleapis/build/src/apis/analyticsdata/index.js').analyticsdata {
+    return sub('analyticsdata').analyticsdata as typeof import('googleapis/build/src/apis/analyticsdata/index.js').analyticsdata;
+  },
+  get androidpublisher(): typeof import('googleapis/build/src/apis/androidpublisher/index.js').androidpublisher {
+    return sub('androidpublisher').androidpublisher as typeof import('googleapis/build/src/apis/androidpublisher/index.js').androidpublisher;
+  },
+  get bigquery(): typeof import('googleapis/build/src/apis/bigquery/index.js').bigquery {
+    return sub('bigquery').bigquery as typeof import('googleapis/build/src/apis/bigquery/index.js').bigquery;
+  },
+  get billingbudgets(): typeof import('googleapis/build/src/apis/billingbudgets/index.js').billingbudgets {
+    return sub('billingbudgets').billingbudgets as typeof import('googleapis/build/src/apis/billingbudgets/index.js').billingbudgets;
+  },
+  get cloudbilling(): typeof import('googleapis/build/src/apis/cloudbilling/index.js').cloudbilling {
+    return sub('cloudbilling').cloudbilling as typeof import('googleapis/build/src/apis/cloudbilling/index.js').cloudbilling;
+  },
+  get cloudresourcemanager(): typeof import('googleapis/build/src/apis/cloudresourcemanager/index.js').cloudresourcemanager {
+    return sub('cloudresourcemanager').cloudresourcemanager as typeof import('googleapis/build/src/apis/cloudresourcemanager/index.js').cloudresourcemanager;
+  },
+  get firebase(): typeof import('googleapis/build/src/apis/firebase/index.js').firebase {
+    return sub('firebase').firebase as typeof import('googleapis/build/src/apis/firebase/index.js').firebase;
+  },
+  get iam(): typeof import('googleapis/build/src/apis/iam/index.js').iam {
+    return sub('iam').iam as typeof import('googleapis/build/src/apis/iam/index.js').iam;
+  },
+  get searchconsole(): typeof import('googleapis/build/src/apis/searchconsole/index.js').searchconsole {
+    return sub('searchconsole').searchconsole as typeof import('googleapis/build/src/apis/searchconsole/index.js').searchconsole;
+  },
+  get serviceusage(): typeof import('googleapis/build/src/apis/serviceusage/index.js').serviceusage {
+    return sub('serviceusage').serviceusage as typeof import('googleapis/build/src/apis/serviceusage/index.js').serviceusage;
+  },
+  get youtube(): typeof import('googleapis/build/src/apis/youtube/index.js').youtube {
+    return sub('youtube').youtube as typeof import('googleapis/build/src/apis/youtube/index.js').youtube;
+  },
 };

--- a/packages/mcp-server/src/playstore/financials.ts
+++ b/packages/mcp-server/src/playstore/financials.ts
@@ -12,7 +12,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import zlib from 'node:zlib';
-import { JWT } from 'google-auth-library';
+import type { JWT } from 'google-auth-library';
+import { newJWT } from '../lib/google-auth-lite.js';
 import { fetchWithTimeout, HTTP_TRANSFER_TIMEOUT_MS } from '../lib/http.js';
 import { requireServiceAccountJson } from '../helpers.js';
 
@@ -77,7 +78,7 @@ function normalizeBucket(raw: string): string {
  */
 function storageClient(packageName?: string): JWT {
   const parsed = JSON.parse(requireServiceAccountJson(packageName));
-  return new JWT({
+  return newJWT({
     email: parsed.client_email,
     key: parsed.private_key,
     scopes: [STORAGE_SCOPE],

--- a/packages/mcp-server/src/playstore/tools.ts
+++ b/packages/mcp-server/src/playstore/tools.ts
@@ -1,6 +1,6 @@
 import { google } from '../lib/googleapis-lite.js';
-import type { OAuth2Client } from 'google-auth-library';
-import { JWT } from 'google-auth-library';
+import type { OAuth2Client, JWT } from 'google-auth-library';
+import { newJWT } from '../lib/google-auth-lite.js';
 import fs from 'node:fs';
 import { extractHttpStatus } from '../lib/google-errors.js';
 
@@ -1136,7 +1136,7 @@ export async function verifyServiceAccountJson(
     };
   }
 
-  const jwt = new JWT({
+  const jwt = newJWT({
     email: parsed.client_email,
     key: parsed.private_key,
     scopes: ['https://www.googleapis.com/auth/androidpublisher'],

--- a/plugins/mimi-seed/.codex-plugin/plugin.json
+++ b/plugins/mimi-seed/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",


### PR DESCRIPTION
## 문제

Claude Code 의 MCP **연결 타임아웃 기본값은 5초**인데, 이 서버는 기동이 그보다 느려서 세션에 따라 mimi-seed 도구가 통째로 등록되지 않는 사고가 반복됐다.

측정(Windows, 같은 머신):

| | |
|---|---|
| 콜드 캐시(실시간 검사 개입) | **25.8s** |
| 워밍 | **4.5 ~ 5.9s** |

워밍 상태에서도 5초 경계에 걸쳐 있어 "붙었다 안 붙었다" 했다.

## 원인

`buildServer()` 자체는 **26ms**다. 나머지는 전부 모듈 그래프 로딩이고, **도구를 하나도 호출하지 않아도** 기동 시점에 지불됐다.

| 항목 | 기동 비용 | 전파 경로 |
|---|---|---|
| googleapis 서브패스 13개 | ~1.4s | `lib/googleapis-lite` → 구현 모듈 9개 |
| `google-auth-library` | ~0.6s | `helpers.ts` → **register 12개** |
| `jose` | ~0.6s | `appstore/auth.ts` → 같은 경로 |

2026-07-24 에 googleapis **배럴**(~19s)을 서브패스로 회피했지만, 그 서브패스도 정적 import 라 1.4s 가 기동에 그대로 남아 있었다.

## 해결

세 가지를 **첫 사용 시점**으로 미뤘다. 핵심은 호출부를 async 로 바꾸지 않은 것 — googleapis 와 google-auth-library 는 `type: module` 도 `exports` 맵도 없는 순수 CJS 라 `createRequire` 로 **동기** 지연 로드가 된다.

- **`lib/googleapis-lite.ts`** — 정적 import → getter + `createRequire`. 타입은 `typeof import(...)` 로 유지해 런타임에서 완전히 소거. **소비자 9개 파일은 한 줄도 바뀌지 않는다.**
- **`lib/google-auth-lite.ts`** (신규) — `new JWT(...)` → `newJWT(...)`. 값 사용처는 5곳뿐이고 나머지 13곳은 이미 `import type` 이라 런타임 비용 0 이었다.
- **`appstore/auth.ts`** — `jose` 는 async 함수 하나(`generateToken`)에서만 쓰여 평범한 동적 import 로 충분.

## 결과 (각 3회 중앙값)

| | 전 | 후 |
|---|---|---|
| 기동 import | 4,849ms | **504ms** |
| MCP 핸드셰이크 | 5,920ms | **545ms** |
| 노출 도구 수 | 230 | 230 (동일) |

미룬 비용은 쓸 때만 낸다 — 첫 Google API 접근 158ms, 이후 추가 API 14ms.
부수 효과로 테스트 스위트 import 시간이 **222s → 23s**.

## 검증

- 빌드 · 린트 · `plugin:check`(CI repo-guards 와 동일) 통과
- 테스트 **556 통과 / 2 skip** — 기준선과 동일
- 실패 1건(`manifest-schema-parity`)은 **이 PR 이전부터** 실패하던 별개 버그다 (Windows 경로를 `new URL()` 에 넘겨 `Invalid URL`). 이 PR 범위 밖이라 손대지 않았다.
- ⚠️ 관련 테스트 5개가 `googleapis-lite` 를 `vi.mock` 으로 통째 대체하므로 **새 지연 로더의 실제 require 경로를 테스트가 타지 않는다.** 그래서 getter 14개 / `newJWT` 인스턴스 생성 / `jose` 동적 import 를 런타임 스모크로 직접 확인했다 (전부 통과).

## 배포

`0.18.1` 로 패치 범프 포함 (`scripts/version.mjs`). main 머지 시 CI 가 npm 자동 publish 한다.
새 버전은 **Claude Code 세션을 재시작해야** 반영된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)