### PR TITLE
fix(test): manifest-schema-parity 가 Windows 에서 Invalid URL 로 죽던 문제

### DIFF
--- a/packages/mcp-server/src/__tests__/manifest-schema-parity.test.ts
+++ b/packages/mcp-server/src/__tests__/manifest-schema-parity.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 
 /**
  * `.mimi-seed.json` 스키마는 **두 패키지에 손으로 복제돼 있다**.
@@ -15,8 +16,12 @@ import { fileURLToPath } from 'node:url';
  * 두 tsconfig(NodeNext vs Bundler)가 서로의 파일을 검사하게 되기 때문이다.
  */
 
+// repoRoot 는 네이티브 경로다. 여기에 `new URL(repoRoot, 'file://')` 를 쓰면 Windows 에서
+// 'C:\...' 가 file:// 기준 상대경로로 유효하지 않아 `TypeError: Invalid URL` 로 죽는다
+// (POSIX 는 '/home/...' 이라 우연히 통과해서 CI 만 보면 안 잡힌다). 형제 테스트
+// ai-model-parity.test.ts 와 동일하게 path.join 으로 이어붙인다.
 const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
-const read = (rel: string) => readFileSync(new URL(rel, new URL(repoRoot, 'file://')), 'utf8');
+const read = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf8');
 
 const MCP = read('packages/mcp-server/src/lib/project-manifest.ts');
 const CLI = read('packages/cli/src/project-manifest.ts');


### PR DESCRIPTION
## 증상

Windows 로컬에서 `npm test` 가 항상 빨갛다.

```
FAIL  src/__tests__/manifest-schema-parity.test.ts (0 test)
TypeError: Invalid URL
 ❯ read src/__tests__/manifest-schema-parity.test.ts:19:44
```

CI(Linux)는 초록불이라 그동안 드러나지 않았다.

## 원인

```ts
const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
const read = (rel) => readFileSync(new URL(rel, new URL(repoRoot, 'file://')), 'utf8');
```

`repoRoot` 는 `fileURLToPath` 를 거친 **네이티브 경로**인데 이를 다시 URL 로 감쌌다.

- POSIX: `new URL('/home/runner/...', 'file://')` → `/` 로 시작하는 절대경로라 **우연히** 통과
- Windows: `new URL('C:\Users\...', 'file://')` → 드라이브 문자 + 백슬래시라 `TypeError: Invalid URL`

게다가 이게 **모듈 최상위**에서 터져서 스위트가 통째로 로드 실패한다. 즉 이 파일의 가드 7개가 Windows 에서 **한 번도 실행된 적이 없다** — 실패한 게 아니라 아예 안 돌았다(`(0 test)`).

## 수정

새 방식을 만들지 않고, 같은 리포의 형제 테스트 `ai-model-parity.test.ts` 가 이미 쓰는 관용구로 통일했다.

```ts
const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
const read = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf8');
```

## 결과 (Windows 로컬)

| | before | after |
|---|---|---|
| Test Files | 57 passed \| **1 failed** | **58 passed** |
| Tests | 556 passed | **563 passed** (+7, 안 돌던 가드) |

린트 통과. 테스트 전용 변경이라 배포물에 영향 없다 (`tsconfig` 가 `src/__tests__/**` 를 exclude). 버전 범프도 하지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)