### PR TITLE
feat(video): 쇼츠 스타일 ASS 자막 + 구독 전용 무료 제작 경로 (0.19.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed",
   "displayName": "Mimi Seed",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube 게시를 Claude Code에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/README.ko.md
+++ b/README.ko.md
@@ -411,7 +411,7 @@ SDK에 기여한다면 **도메인 온톨로지** [`docs/domain/`](docs/domain/)
 | **Android 서명** | 3 | `android_signing_setup` · `android_generate_keystore` · `jenkins_upload_playstore_sa` |
 | **인증** | 4 | `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
 | **AI** | 2 | `generate_release_notes_from_commits` · `generate_review_reply` |
-| **영상 제작** | 14 | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_render` |
+| **영상 제작** | 15 | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_render` |
 
 전체 카탈로그 → [`docs/domain/tool-catalog.md`](docs/domain/tool-catalog.md) · 소스 → [packages/mcp-server](packages/mcp-server)
 

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ full tool catalog, the auth/credential model, and known pitfalls — start at
 | **Android signing** | 3 | `android_signing_setup` · `android_generate_keystore` · `jenkins_upload_playstore_sa` |
 | **Auth** | 4 | `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
 | **AI** | 2 | `generate_release_notes_from_commits` · `generate_review_reply` |
-| **Video production** | 14 | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_render` |
+| **Video production** | 15 | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_render` |
 
 Full catalog → [`docs/domain/tool-catalog.md`](docs/domain/tool-catalog.md) · source → [packages/mcp-server](packages/mcp-server)
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -80,7 +80,7 @@ you can paste. Pick the row for the job; batching two rows in one `select:` call
 | CI (GitHub/GitLab) | `select:ci_save_config,ci_list_workflows,ci_trigger_build,ci_get_build_status,ci_list_recent_builds,ci_cancel_build` |
 | Android signing / keystore | `select:android_signing_setup,android_generate_keystore,jenkins_upload_keystore,jenkins_upload_playstore_sa` |
 | Service account end-to-end | `select:iam_list_service_accounts,iam_create_service_account,iam_list_keys,iam_create_key,iam_add_iam_policy_binding,setup_playstore_connection,playstore_register_service_account,playstore_verify_service_account,playstore_list_service_accounts,playstore_delete_service_account` |
-| Story → researched video | `select:video_plan_from_story,video_research_youtube,video_search_stock_assets,video_synthesize_research,video_download_stock_assets,video_generate_image,video_add_local_asset,video_build_timeline,video_render,video_job_status,video_validate` |
+| Story → researched video | `select:video_save_plan,video_plan_from_story,video_research_youtube,video_search_stock_assets,video_synthesize_research,video_download_stock_assets,video_generate_image,video_add_local_asset,video_build_timeline,video_render,video_job_status,video_validate` |
 | YouTube upload / publish | `select:youtube_upload_video,youtube_get_video_status,youtube_update_video_privacy,mimi_seed_auth_start` |
 
 ---
@@ -191,7 +191,7 @@ per-domain inventory is [`docs/domain/tool-catalog.md`](domain/tool-catalog.md).
 | **TikTok Business** | `tiktok_business_auth_status` · `tiktok_business_plan_video_post` · `tiktok_business_publish_video` · `tiktok_business_get_publish_status` |
 | **Checks** | `playstore_check_submission_risks` · `appstore_check_submission_risks` · `screenshot_validate` · `release_status` |
 | **AI / Auth** | `generate_release_notes_from_commits` · `generate_review_reply` · `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
-| **Video production** | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
+| **Video production** | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_save_plan` · `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
 
 ---
 
@@ -218,15 +218,16 @@ For visual production, use the bundled `video-create-publish` skill. It requires
 aspect-ratio-specific human-safe crops, video-native motion, an original-resolution frame review, and a saved
 contact sheet; codec validation alone is not a quality pass.
 
-1. `video_plan_from_story` — create the project and scene plan.
+1. `video_save_plan` — save an agent-authored storyboard (no API key; free-path default). `video_plan_from_story` is the metered alternative when `ANTHROPIC_API_KEY` is configured.
 2. `video_research_youtube` — collect reference-only metadata; never treat a result as a render asset.
 3. `video_search_stock_assets` — find licensed Pexels candidates.
 4. `video_synthesize_research` — combine metadata with any direct human/agent observations. Treat its output as
    metadata-bounded guidance, not proof that the source videos were watched.
 5. Preview then confirm `video_download_stock_assets`; use `video_generate_image(confirm=false)` before any paid
-   generation and call it again with `confirm=true` only after approval. User-owned media goes through
-   `video_add_local_asset` with its ownership/license basis.
-6. `video_build_timeline` — provenance-gated scene assignment.
+   generation and call it again with `confirm=true` only after approval. On the free path, generate scene images
+   with the local `codex` CLI (ChatGPT subscription) instead and register them — like all user-owned media —
+   through `video_add_local_asset` with the ownership/license basis.
+6. `video_build_timeline` — provenance-gated scene assignment. Captions burn in the shorts style (bold outline, `**keyword**` highlight); tune with `captionStyle`.
 7. Preview then confirm `video_render`; poll `video_job_status`, then run `video_validate` on the completed MP4.
 
 > **Mimi Seed does not compile app binaries.** It manages metadata, store releases, and

--- a/docs/domain/tool-catalog.md
+++ b/docs/domain/tool-catalog.md
@@ -1,4 +1,4 @@
-# Tool catalog — 230 tools across 21 domains
+# Tool catalog — 231 tools across 21 domains
 
 > The MCP server's "entities". One row per domain → register file → tools, with **W** (write) and **D**
 > (destructive / near-irreversible) markers. Everything unmarked is read-only.
@@ -31,8 +31,8 @@
 | Auth | `registers/auth.ts` | 4 |
 | Android signing | `registers/android.ts` | 3 |
 | AI | `registers/ai.ts` | 2 |
-| Video production | `registers/video.ts` | 14 |
-| **Total** | **21 modules** | **230** |
+| Video production | `registers/video.ts` | 15 |
+| **Total** | **21 modules** | **231** |
 
 ## Google Play — `registers/playstore.ts` (39) · impl `playstore/tools.ts`
 
@@ -131,13 +131,14 @@
 | Auth (`auth.ts`) | `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
 | AI (`ai.ts`) — needs `ANTHROPIC_API_KEY` | `generate_release_notes_from_commits` · `generate_review_reply` |
 
-## Video production — `registers/video.ts` (14) · impl `video/*.ts`
+## Video production — `registers/video.ts` (15) · impl `video/*.ts`
 
 - Research/read: `youtube_get_video_status` · `video_research_youtube` (metadata/reference-only) ·
   `video_search_stock_assets` · `video_job_status` · `video_validate`
 - **W** `youtube_upload_video` (기본 private, public/unlisted는 명시 확인 필수) ·
   `youtube_update_video_privacy` (public/unlisted는 명시 확인 필수)
-- **W** `video_plan_from_story` (Anthropic + local project) · `video_synthesize_research` (metadata/user notes →
+- **W** `video_plan_from_story` (Anthropic + local project) · `video_save_plan` (agent-authored storyboard,
+  no API key — free-path default) · `video_synthesize_research` (metadata/user notes →
   bounded brief) · `video_download_stock_assets` (Pexels, preview then
   confirm) · `video_generate_image` (OpenAI, preview then confirm) · `video_add_local_asset` ·
   `video_build_timeline` · `video_render` (local FFmpeg job, preview then confirm)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mimi-seed-sdk",
   "private": true,
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Monorepo root — the SDK version (SSOT for both packages and client plugin manifests) plus bootstrap scripts. The publishable packages live in packages/. This is NOT an npm workspace: each package installs independently.",
   "type": "module",
   "engines": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mimi-seed",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mimi-seed",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Mimi Seed CLI \u2014 Claude Code\uc640 Codex\uc5d0\uc11c \uc571 \ucd9c\uc2dc \uc6b4\uc601\uc744 \uad00\ub9ac\ud569\ub2c8\ub2e4.",
   "bin": {
     "mimi-seed": "dist/index.js"

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -99,7 +99,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 | Android 서명 | 3 | `android_signing_setup` / `android_generate_keystore` / `jenkins_upload_playstore_sa` |
 | 인증 | 4 | `mimi_seed_status` / `mimi_seed_auth_start` / `mimi_seed_auth_status` / `mimi_seed_remote_sync_credentials` |
 | AI (Claude) | 2 | `generate_release_notes_from_commits` / `generate_review_reply` |
-| 영상 제작·YouTube | 14 | `youtube_upload_video` / `youtube_get_video_status` / `youtube_update_video_privacy` / `video_plan_from_story` / `video_render` |
+| 영상 제작·YouTube | 15 | `youtube_upload_video` / `youtube_get_video_status` / `youtube_update_video_privacy` / `video_plan_from_story` / `video_render` |
 
 > 인앱 결제(IAP·구독) 도구는 위 Play Store·App Store 카운트에 포함됩니다 — `appstore_create_inapp_purchase` · `appstore_update_product_review_note` · `appstore_upload_product_review_screenshot` 등.
 > 전체 카탈로그(항상 최신): [`docs/domain/tool-catalog.md`](../../docs/domain/tool-catalog.md)

--- a/packages/mcp-server/assets/agent-guide.md
+++ b/packages/mcp-server/assets/agent-guide.md
@@ -80,7 +80,7 @@ you can paste. Pick the row for the job; batching two rows in one `select:` call
 | CI (GitHub/GitLab) | `select:ci_save_config,ci_list_workflows,ci_trigger_build,ci_get_build_status,ci_list_recent_builds,ci_cancel_build` |
 | Android signing / keystore | `select:android_signing_setup,android_generate_keystore,jenkins_upload_keystore,jenkins_upload_playstore_sa` |
 | Service account end-to-end | `select:iam_list_service_accounts,iam_create_service_account,iam_list_keys,iam_create_key,iam_add_iam_policy_binding,setup_playstore_connection,playstore_register_service_account,playstore_verify_service_account,playstore_list_service_accounts,playstore_delete_service_account` |
-| Story → researched video | `select:video_plan_from_story,video_research_youtube,video_search_stock_assets,video_synthesize_research,video_download_stock_assets,video_generate_image,video_add_local_asset,video_build_timeline,video_render,video_job_status,video_validate` |
+| Story → researched video | `select:video_save_plan,video_plan_from_story,video_research_youtube,video_search_stock_assets,video_synthesize_research,video_download_stock_assets,video_generate_image,video_add_local_asset,video_build_timeline,video_render,video_job_status,video_validate` |
 | YouTube upload / publish | `select:youtube_upload_video,youtube_get_video_status,youtube_update_video_privacy,mimi_seed_auth_start` |
 
 ---
@@ -191,7 +191,7 @@ per-domain inventory is [`docs/domain/tool-catalog.md`](domain/tool-catalog.md).
 | **TikTok Business** | `tiktok_business_auth_status` · `tiktok_business_plan_video_post` · `tiktok_business_publish_video` · `tiktok_business_get_publish_status` |
 | **Checks** | `playstore_check_submission_risks` · `appstore_check_submission_risks` · `screenshot_validate` · `release_status` |
 | **AI / Auth** | `generate_release_notes_from_commits` · `generate_review_reply` · `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
-| **Video production** | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
+| **Video production** | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_save_plan` · `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
 
 ---
 
@@ -218,15 +218,16 @@ For visual production, use the bundled `video-create-publish` skill. It requires
 aspect-ratio-specific human-safe crops, video-native motion, an original-resolution frame review, and a saved
 contact sheet; codec validation alone is not a quality pass.
 
-1. `video_plan_from_story` — create the project and scene plan.
+1. `video_save_plan` — save an agent-authored storyboard (no API key; free-path default). `video_plan_from_story` is the metered alternative when `ANTHROPIC_API_KEY` is configured.
 2. `video_research_youtube` — collect reference-only metadata; never treat a result as a render asset.
 3. `video_search_stock_assets` — find licensed Pexels candidates.
 4. `video_synthesize_research` — combine metadata with any direct human/agent observations. Treat its output as
    metadata-bounded guidance, not proof that the source videos were watched.
 5. Preview then confirm `video_download_stock_assets`; use `video_generate_image(confirm=false)` before any paid
-   generation and call it again with `confirm=true` only after approval. User-owned media goes through
-   `video_add_local_asset` with its ownership/license basis.
-6. `video_build_timeline` — provenance-gated scene assignment.
+   generation and call it again with `confirm=true` only after approval. On the free path, generate scene images
+   with the local `codex` CLI (ChatGPT subscription) instead and register them — like all user-owned media —
+   through `video_add_local_asset` with the ownership/license basis.
+6. `video_build_timeline` — provenance-gated scene assignment. Captions burn in the shorts style (bold outline, `**keyword**` highlight); tune with `captionStyle`.
 7. Preview then confirm `video_render`; poll `video_job_status`, then run `video_validate` on the completed MP4.
 
 > **Mimi Seed does not compile app binaries.** It manages metadata, store releases, and

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoonion/mimi-seed-mcp",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonion/mimi-seed-mcp",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Mimi Seed MCP server \u2014 Firebase + AdMob + Google Play + App Store management for Claude Code / Codex / Cursor / any MCP client.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/__tests__/video-tools.test.ts
+++ b/packages/mcp-server/src/__tests__/video-tools.test.ts
@@ -2,9 +2,10 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'nod
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { addLocalAsset, buildTimeline, loadTimeline, registerAsset, __testing as projectTesting } from '../video/project.js';
+import { addLocalAsset, buildTimeline, loadTimeline, registerAsset, savePlan, __testing as projectTesting } from '../video/project.js';
 import { __testing as providerTesting } from '../video/providers.js';
-import { buildFfmpegPlan, formatSrt, __testing as renderTesting } from '../video/render.js';
+import { formatAss, resolveCaptionStyle } from '../video/captions.js';
+import { buildFfmpegPlan, __testing as renderTesting } from '../video/render.js';
 import { __testing as researchTesting } from '../video/research.js';
 import type { VideoProject, VideoTimeline } from '../video/types.js';
 
@@ -62,6 +63,38 @@ describe('video project provenance', () => {
     expect(scenes).toHaveLength(5);
     expect(scenes.reduce((sum, scene) => sum + scene.durationSec, 0)).toBe(5);
     expect(scenes.every((scene) => scene.durationSec >= 1)).toBe(true);
+  });
+
+  it('saves an agent-authored plan without any AI API key', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'mimi-seed-video-plan-'));
+    dirs.push(dir);
+    const project = savePlan({
+      projectDir: dir,
+      title: '무료 쇼츠',
+      story: '구독 토큰만으로 만든 영상',
+      language: 'ko',
+      aspectRatio: '9:16',
+      targetDurationSec: 10,
+      scenes: [
+        { durationSec: 4, onScreenText: '이건 **무료**', visualPrompt: 'a coffee bean sprouting' },
+        { durationSec: 6, narration: '결론', visualPrompt: 'sunrise over a farm' },
+      ],
+    });
+    expect(project.scenes).toHaveLength(2);
+    expect(project.scenes[0].id).toBe('scene-1');
+    expect(project.scenes[1].searchQuery).toBe('sunrise over a farm');
+    expect(JSON.parse(readFileSync(path.join(dir, 'project.json'), 'utf8')).title).toBe('무료 쇼츠');
+    // 길이 합계가 target과 다르면 스키마가 거부한다
+    expect(() => savePlan({
+      projectDir: dir,
+      title: 'x',
+      story: 'y',
+      language: 'ko',
+      aspectRatio: '9:16',
+      targetDurationSec: 10,
+      scenes: [{ durationSec: 3 }],
+      overwrite: true,
+    })).toThrow('영상 프로젝트 파일 검증 실패');
   });
 
   it('copies a user-owned asset and builds a renderable timeline', () => {
@@ -123,7 +156,7 @@ describe('video project provenance', () => {
 });
 
 describe('video render planning', () => {
-  it('writes SRT timing and produces a single-process FFmpeg plan', () => {
+  it('writes ASS captions and produces a single-process FFmpeg plan', () => {
     const projectDir = fixtureProject();
     const source = path.join(projectDir, 'source.png');
     writeFileSync(source, Buffer.from('fake image'));
@@ -141,46 +174,76 @@ describe('video render planning', () => {
     const plan = buildFfmpegPlan(projectDir, path.join(projectDir, 'render', 'out.mp4'), 'job-1');
     expect(plan.args).toContain('-filter_complex');
     expect(plan.args.join(' ')).toContain('concat=n=2');
-    expect(plan.args.join(' ')).toContain('subtitles=render/captions-job-1.srt');
+    expect(plan.args.join(' ')).toContain('subtitles=render/captions-job-1.ass');
+    expect(plan.args.join(' ')).not.toContain('force_style');
+    const ass = readFileSync(plan.subtitlePath!, 'utf8');
+    expect(ass).toContain('PlayResX: 1080');
+    expect(ass).toContain('PlayResY: 1920');
   });
 
-  it('formats cumulative subtitle ranges', () => {
-    const timeline: VideoTimeline = {
+  function captionTimeline(scenes: VideoTimeline['scenes'], overrides?: Partial<VideoTimeline>): VideoTimeline {
+    return {
       version: 1,
       projectId: PROJECT_ID,
       createdAt: new Date(0).toISOString(),
       width: 1080,
       height: 1920,
       fps: 30,
-      totalDurationSec: 4,
-      scenes: [
-        { id: 'one', assetId: 'a', durationSec: 1.25, onScreenText: 'One' },
-        { id: 'two', assetId: 'b', durationSec: 2.75, onScreenText: 'Two' },
-      ],
+      totalDurationSec: scenes.reduce((sum, scene) => sum + scene.durationSec, 0),
+      scenes,
+      ...overrides,
     };
-    expect(formatSrt(timeline)).toContain('00:00:01,250 --> 00:00:04,000');
+  }
+
+  it('formats cumulative caption ranges in ASS time', () => {
+    const timeline = captionTimeline([
+      { id: 'one', assetId: 'a', durationSec: 1.25, onScreenText: 'One' },
+      { id: 'two', assetId: 'b', durationSec: 2.75, onScreenText: 'Two' },
+    ]);
+    const ass = formatAss(timeline, resolveCaptionStyle(1080, 1920));
+    expect(ass).toContain('Dialogue: 0,0:00:01.25,0:00:04.00,Caption');
   });
 
-  it('sanitizes subtitle control syntax instead of passing it to libass', () => {
-    const timeline: VideoTimeline = {
-      version: 1,
-      projectId: PROJECT_ID,
-      createdAt: new Date(0).toISOString(),
-      width: 1080,
-      height: 1920,
-      fps: 30,
-      totalDurationSec: 1,
-      scenes: [{
-        id: 'one',
-        assetId: 'a',
-        durationSec: 1,
-        onScreenText: '<font>{\\an8}x</font>\n\n2\n00:00:00,000 --> 99:00:00,000',
-      }],
-    };
-    const srt = formatSrt(timeline);
-    expect(srt).not.toContain('<font>');
-    expect(srt).not.toContain('--> 99:');
-    expect(srt).toContain('｛\\an8｝');
+  it('applies shorts defaults: bold outline style, lower-middle placement, no opaque box', () => {
+    const style = resolveCaptionStyle(1080, 1920);
+    expect(style.fontSizePx).toBe(81);
+    expect(style.position).toBe('lower-middle');
+    const ass = formatAss(captionTimeline([
+      { id: 'one', assetId: 'a', durationSec: 2, onScreenText: '첫 장면' },
+    ]), style);
+    // BorderStyle=1(외곽선), Alignment=2, MarginV=1920*0.28=538
+    expect(ass).toMatch(/Style: Caption,Malgun Gothic,81,&H00FFFFFF,&H00FFFFFF,&H00000000,&H80000000,-1,0,0,0,100,100,0,0,1,4,0,2,97,97,538,1/);
+    expect(ass).toContain('{\\fad(120,80)}');
+  });
+
+  it('renders **keyword** markup as a highlight color run', () => {
+    const ass = formatAss(captionTimeline([
+      { id: 'one', assetId: 'a', durationSec: 2, onScreenText: '이건 **진짜** 무료' },
+    ]), resolveCaptionStyle(1080, 1920));
+    expect(ass).toContain('{\\1c&H0000D4FF&}진짜{\\1c&H00FFFFFF&}');
+    expect(ass).not.toContain('**');
+  });
+
+  it('renders the box preset with a translucent box for tutorials', () => {
+    const style = resolveCaptionStyle(1080, 1920, { preset: 'box' });
+    const ass = formatAss(captionTimeline([
+      { id: 'one', assetId: 'a', durationSec: 2, onScreenText: '단계 1' },
+    ]), style);
+    expect(ass).toMatch(/,3,\d+,0,2,/); // BorderStyle=3
+    expect(ass).toContain('&H50000000');
+  });
+
+  it('sanitizes caption control syntax instead of passing it to libass', () => {
+    const ass = formatAss(captionTimeline([{
+      id: 'one',
+      assetId: 'a',
+      durationSec: 1,
+      onScreenText: '<font>{\\an8}x</font>\n\\N주입',
+    }]), resolveCaptionStyle(1080, 1920));
+    expect(ass).not.toContain('<font>');
+    expect(ass).not.toContain('{\\an8}');
+    expect(ass).toContain('｛＼an8｝');
+    expect(ass).toContain('＼N주입');
   });
 
   it('rejects a hand-edited timeline before values reach FFmpeg filters', () => {

--- a/packages/mcp-server/src/registers/video.ts
+++ b/packages/mcp-server/src/registers/video.ts
@@ -6,6 +6,7 @@ import {
   loadProject,
   loadTimeline,
   planStory,
+  savePlan,
 } from '../video/project.js';
 import {
   downloadStockAssets,
@@ -109,6 +110,35 @@ export function registerVideoTools(server: McpServer) {
       overwrite: z.boolean().default(false).describe('기존 메타데이터를 .history에 보관하고 새 프로젝트로 덮어쓸지 여부'),
     },
     async (input) => text(await planStory(input)),
+  );
+
+  server.tool(
+    'video_save_plan',
+    [
+      '에이전트가 직접 작성한 장면별 스토리보드를 project.json으로 저장합니다. API 키가 필요 없는 video_plan_from_story의 무료 대안입니다.',
+      '스토리보드(장면 분할·내레이션·화면 문구·시각 프롬프트)는 호출 전에 에이전트가 직접 설계하세요.',
+      '장면 durationSec 합계는 targetDurationSec와 일치해야 합니다(허용 오차 0.1초).',
+      '기존 project.json은 overwrite=true 없이는 덮어쓰지 않습니다.',
+    ].join(' '),
+    {
+      projectDir: absolutePath,
+      title: z.string().min(1).max(500).describe('영상 제목'),
+      story: z.string().min(1).max(200_000).describe('영상으로 만들 story 원문'),
+      language: z.string().default('ko').describe('내레이션과 화면 문구 언어'),
+      aspectRatio: z.enum(['9:16', '16:9', '1:1']).default('9:16').describe('출력 화면비'),
+      targetDurationSec: z.number().min(5).max(300).default(30).describe('목표 영상 길이(초)'),
+      scenes: z.array(z.object({
+        id: z.string().min(1).max(100).optional(),
+        durationSec: z.number().positive().max(300),
+        narration: z.string().max(10_000).optional(),
+        onScreenText: z.string().max(2_000).optional().describe('화면 자막. **단어** 마크업으로 키워드 하이라이트'),
+        visualPrompt: z.string().max(10_000).optional().describe('이미지 생성용 프롬프트'),
+        searchQuery: z.string().max(1_000).optional().describe('스톡 영상 검색용 영문 검색어'),
+      })).min(1).max(12),
+      style: z.string().max(10_000).optional().describe('시각 스타일과 톤'),
+      overwrite: z.boolean().default(false).describe('기존 메타데이터를 .history에 보관하고 새 프로젝트로 덮어쓸지 여부'),
+    },
+    async (input) => text(savePlan(input)),
   );
 
   server.tool(
@@ -237,7 +267,8 @@ export function registerVideoTools(server: McpServer) {
     [
       '등록된 이미지·영상 자산을 장면 순서와 길이에 맞춰 timeline.json으로 조합합니다.',
       'assets.json에서 allowedForRendering=true이고 reference-only가 아닌 자산만 허용합니다.',
-      '화면 문구는 최종 렌더에서 자막으로 번인됩니다.',
+      '화면 문구는 최종 렌더에서 쇼츠 스타일 자막(굵은 폰트·흰 글자·검정 외곽선)으로 번인되며, onScreenText 안의 **단어** 마크업은 하이라이트 컬러(기본 노랑)로 강조됩니다.',
+      '한 장면 자막은 3~5어절·최대 2줄로 짧게 쓰고, 하이라이트는 문장당 한 단어만 지정하세요.',
     ].join(' '),
     {
       projectDir: absolutePath,
@@ -245,19 +276,29 @@ export function registerVideoTools(server: McpServer) {
         id: z.string().min(1),
         assetId: z.string().min(1),
         durationSec: z.number().positive().max(300),
-        onScreenText: z.string().optional(),
+        onScreenText: z.string().optional().describe('번인 자막. **단어**로 키워드 1개 하이라이트, \\n으로 의미 단위 줄바꿈'),
         narration: z.string().optional(),
       })).min(1).max(30),
       audioAssetId: z.string().optional(),
+      captionStyle: z.object({
+        preset: z.enum(['shorts', 'box']).optional().describe('shorts(기본): 외곽선 자막+하이라이트 / box: 반투명 박스 자막(튜토리얼용)'),
+        fontName: z.string().min(1).max(200).optional().describe('설치된 굵은 한글 고딕 폰트명(예: Pretendard, 에스코어드림). 생략 시 Malgun Gothic Bold'),
+        fontSizePx: z.number().int().min(24).max(400).optional().describe('생략 시 세로 영상은 높이의 4.2%(1080×1920 기준 81px)'),
+        textColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+        outlineColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+        highlightColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional().describe('**단어** 마크업 색. 기본 #FFD400'),
+        position: z.enum(['lower', 'lower-middle', 'center']).optional().describe('생략 시 9:16은 lower-middle(하단-중앙 1/3, 쇼츠 UI 안전영역)'),
+      }).optional().describe('자막 스타일. 생략하면 쇼츠 기본 스타일'),
     },
-    async ({ projectDir, scenes, audioAssetId }) => text(buildTimeline(projectDir, scenes, audioAssetId)),
+    async ({ projectDir, scenes, audioAssetId, captionStyle }) =>
+      text(buildTimeline(projectDir, scenes, audioAssetId, captionStyle)),
   );
 
   server.tool(
     'video_render',
     [
       'timeline.json과 등록 자산을 FFmpeg로 합성해 MP4 렌더 작업을 시작합니다.',
-      '이미지/영상 크롭, 장면 연결, 화면 문구 번인, 선택적 배경음, H.264/yuv420p 출력을 지원합니다.',
+      '이미지/영상 크롭, 장면 연결, 쇼츠 스타일 자막 번인(timeline.json의 captionStyle 적용), 선택적 배경음, H.264/yuv420p 출력을 지원합니다.',
       'confirm=false는 계획만 반환합니다. CPU를 사용하는 로컬 쓰기 작업이므로 승인 후 confirm=true로 호출하세요.',
       '즉시 jobId를 반환하므로 video_job_status로 완료 여부를 확인하세요.',
     ].join(' '),

--- a/packages/mcp-server/src/video/captions.ts
+++ b/packages/mcp-server/src/video/captions.ts
@@ -1,0 +1,130 @@
+import type { VideoCaptionStyle, VideoTimeline } from './types.js';
+
+/**
+ * 쇼츠 자막 스타일 시스템 — SRT + force_style(Arial 18px) 하드코딩을 대체한다.
+ *
+ * 기본 preset 'shorts'는 2026 숏폼 표준(Bold Highlight 스타일)을 따른다:
+ * 굵은 고딕 + 흰 글자 + 검정 외곽선(불투명 박스 없음), 9:16에서는 하단-중앙 1/3 배치,
+ * `**단어**` 마크업으로 문장당 키워드 1개만 하이라이트 컬러.
+ * 'box' preset은 튜토리얼용 반투명 박스 자막(Subtitle Block 스타일)이다.
+ */
+
+export type CaptionPosition = 'lower' | 'lower-middle' | 'center';
+
+export interface ResolvedCaptionStyle {
+  fontName: string;
+  fontSizePx: number;
+  textColor: string;
+  outlineColor: string;
+  highlightColor: string;
+  position: CaptionPosition;
+  boxed: boolean;
+}
+
+export function resolveCaptionStyle(
+  width: number,
+  height: number,
+  style?: VideoCaptionStyle,
+): ResolvedCaptionStyle {
+  const preset = style?.preset ?? 'shorts';
+  const vertical = height > width;
+  return {
+    // Malgun Gothic은 어떤 Windows에도 있는 폴백. 스킬은 설치된 굵은 고딕(Pretendard 등)을 우선 지정한다.
+    fontName: style?.fontName ?? 'Malgun Gothic',
+    // 세로 쇼츠 기준 height의 4.2% ≈ 81px(1080×1920) — 숏폼 권장(55~75pt)과 한국어 예능 자막(72~96px) 사이.
+    fontSizePx: style?.fontSizePx ?? Math.round(height * (vertical ? 0.042 : 0.055)),
+    textColor: style?.textColor ?? '#FFFFFF',
+    outlineColor: style?.outlineColor ?? '#000000',
+    highlightColor: style?.highlightColor ?? '#FFD400',
+    position: style?.position ?? (preset === 'shorts' && vertical ? 'lower-middle' : 'lower'),
+    boxed: preset === 'box',
+  };
+}
+
+/** #RRGGBB → ASS &HAABBGGRR. alpha 00=불투명, FF=투명. */
+export function assColor(hex: string, alpha = '00'): string {
+  const match = /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/.exec(hex);
+  if (!match) throw new Error(`잘못된 색상 형식입니다(#RRGGBB): ${hex}`);
+  const [, r, g, b] = match;
+  return `&H${alpha}${b}${g}${r}`.toUpperCase();
+}
+
+/** ASS 태그·마크업 주입을 막는다. `**`는 하이라이트 마크업으로 살려둔다. */
+function sanitizeCaptionText(value: string): string {
+  return value
+    .replace(/\r/g, '')
+    .replace(/\n{2,}/g, '\n')
+    .replace(/\\/g, '＼')
+    .replace(/</g, '＜')
+    .replace(/>/g, '＞')
+    .replace(/{/g, '｛')
+    .replace(/}/g, '｝')
+    .trim();
+}
+
+function assTime(seconds: number): string {
+  const cs = Math.max(0, Math.round(seconds * 100));
+  const hours = Math.floor(cs / 360_000);
+  const minutes = Math.floor((cs % 360_000) / 6_000);
+  const secs = Math.floor((cs % 6_000) / 100);
+  const centis = cs % 100;
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${hours}:${pad(minutes)}:${pad(secs)}.${pad(centis)}`;
+}
+
+/** `**단어**` → 하이라이트 컬러 런. 줄바꿈은 \N. */
+function renderEventText(raw: string, style: ResolvedCaptionStyle): string {
+  const primary = assColor(style.textColor);
+  const highlight = assColor(style.highlightColor);
+  return sanitizeCaptionText(raw)
+    .replace(/\*\*([^*\n]+)\*\*/g, `{\\1c${highlight}&}$1{\\1c${primary}&}`)
+    .replace(/\n/g, '\\N');
+}
+
+export function formatAss(timeline: VideoTimeline, style: ResolvedCaptionStyle): string {
+  const { width, height } = timeline;
+  const vertical = height > width;
+  const alignment = style.position === 'center' ? 5 : 2;
+  const marginX = Math.round(width * 0.09);
+  const marginV = style.position === 'center'
+    ? 0
+    : style.position === 'lower-middle'
+      ? Math.round(height * 0.28)
+      : Math.round(height * (vertical ? 0.12 : 0.08));
+  // 한글은 받침 내부 공간이 좁아 외곽선을 폰트 크기의 5.5%로 제한한다. box는 outline 값이 패딩이 된다.
+  const outlinePx = style.boxed
+    ? Math.round(style.fontSizePx * 0.25)
+    : Math.max(2, Math.round(style.fontSizePx * 0.055));
+  const outlineColour = style.boxed ? assColor(style.outlineColor, '50') : assColor(style.outlineColor);
+
+  const events: string[] = [];
+  let cursor = 0;
+  for (const scene of timeline.scenes) {
+    const start = cursor;
+    cursor += scene.durationSec;
+    const text = renderEventText(scene.onScreenText ?? '', style);
+    if (!text) continue;
+    events.push(`Dialogue: 0,${assTime(start)},${assTime(cursor)},Caption,,0,0,0,{\\fad(120,80)}${text}`);
+  }
+  if (events.length === 0) return '';
+
+  return [
+    '[Script Info]',
+    'ScriptType: v4.00+',
+    `PlayResX: ${width}`,
+    `PlayResY: ${height}`,
+    'WrapStyle: 0',
+    'ScaledBorderAndShadow: yes',
+    '',
+    '[V4+ Styles]',
+    'Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding',
+    `Style: Caption,${style.fontName},${style.fontSizePx},${assColor(style.textColor)},${assColor(style.textColor)},${outlineColour},&H80000000,-1,0,0,0,100,100,0,0,${style.boxed ? 3 : 1},${outlinePx},0,${alignment},${marginX},${marginX},${marginV},1`,
+    '',
+    '[Events]',
+    'Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Text',
+    ...events,
+    '',
+  ].join('\n');
+}
+
+export const __testing = { sanitizeCaptionText, assTime, renderEventText };

--- a/packages/mcp-server/src/video/project.ts
+++ b/packages/mcp-server/src/video/project.ts
@@ -19,6 +19,7 @@ import type {
   VideoAssetKind,
   VideoAssetManifest,
   VideoAssetSource,
+  VideoCaptionStyle,
   VideoProject,
   VideoScenePlan,
   VideoTimeline,
@@ -130,6 +131,12 @@ export async function planStory(input: PlanStoryInput): Promise<VideoProject> {
     scenes: normalizeScenes(parsed.scenes ?? [], input.targetDurationSec),
   }, 'AI가 생성한 영상 프로젝트');
 
+  persistProject(projectDir, project, input.overwrite === true);
+  return project;
+}
+
+function persistProject(projectDir: string, project: VideoProject, overwrite: boolean): void {
+  const projectPath = path.join(projectDir, PROJECT_FILE);
   mkdirSync(projectDir, { recursive: true });
   mkdirSync(path.join(projectDir, 'assets', 'stock'), { recursive: true });
   mkdirSync(path.join(projectDir, 'assets', 'generated'), { recursive: true });
@@ -137,7 +144,7 @@ export async function planStory(input: PlanStoryInput): Promise<VideoProject> {
   mkdirSync(path.join(projectDir, 'research'), { recursive: true });
   mkdirSync(path.join(projectDir, 'render'), { recursive: true });
   mkdirSync(path.join(projectDir, '.jobs'), { recursive: true });
-  if (existsSync(projectPath) && input.overwrite) {
+  if (existsSync(projectPath) && overwrite) {
     const archiveDir = path.join(projectDir, '.history', `${Date.now()}-${project.projectId}`);
     mkdirSync(archiveDir, { recursive: true });
     for (const name of [PROJECT_FILE, ASSET_FILE, TIMELINE_FILE]) {
@@ -153,6 +160,57 @@ export async function planStory(input: PlanStoryInput): Promise<VideoProject> {
     projectId: project.projectId,
     assets: [],
   } satisfies VideoAssetManifest);
+}
+
+export interface SavePlanInput {
+  projectDir: string;
+  title: string;
+  story: string;
+  language: string;
+  aspectRatio: VideoAspectRatio;
+  targetDurationSec: number;
+  scenes: Array<Partial<VideoScenePlan> & Pick<VideoScenePlan, 'durationSec'>>;
+  style?: string;
+  overwrite?: boolean;
+}
+
+/**
+ * 에이전트(구독 세션)가 직접 작성한 스토리보드를 API 키 없이 project.json으로 저장한다.
+ * video_plan_from_story(ANTHROPIC_API_KEY 필요)의 무료 대안.
+ * 장면 길이 합계가 targetDurationSec와 일치해야 projectSchema 검증을 통과한다.
+ */
+export function savePlan(input: SavePlanInput): VideoProject {
+  const projectDir = requireAbsolutePath(input.projectDir, 'projectDir');
+  const projectPath = path.join(projectDir, PROJECT_FILE);
+  if (existsSync(projectPath) && !input.overwrite) {
+    throw new Error(`이미 영상 프로젝트가 있습니다: ${projectPath}\noverwrite=true로 명시해야 덮어씁니다.`);
+  }
+  const dims = dimensions(input.aspectRatio);
+  const project = parseFile(projectSchema, {
+    version: 1,
+    projectId: randomUUID(),
+    title: input.title,
+    story: input.story,
+    language: input.language,
+    createdAt: new Date().toISOString(),
+    settings: {
+      aspectRatio: input.aspectRatio,
+      ...dims,
+      fps: 30,
+      targetDurationSec: input.targetDurationSec,
+      style: input.style,
+    },
+    scenes: input.scenes.map((scene, index) => ({
+      id: scene.id?.trim() || `scene-${index + 1}`,
+      durationSec: scene.durationSec,
+      narration: scene.narration?.trim() ?? '',
+      onScreenText: scene.onScreenText?.trim() ?? '',
+      visualPrompt: scene.visualPrompt?.trim() ?? '',
+      searchQuery: scene.searchQuery?.trim() || scene.visualPrompt?.trim() || '',
+    })),
+  }, '에이전트가 작성한 영상 프로젝트');
+
+  persistProject(projectDir, project, input.overwrite === true);
   return project;
 }
 
@@ -245,6 +303,7 @@ export function buildTimeline(
   projectDir: string,
   scenes: VideoTimelineScene[],
   audioAssetId?: string,
+  captionStyle?: VideoCaptionStyle,
 ): VideoTimeline {
   const dir = requireAbsolutePath(projectDir, 'projectDir');
   const project = loadProject(dir);
@@ -284,6 +343,7 @@ export function buildTimeline(
     totalDurationSec,
     scenes,
     audioAssetId,
+    captionStyle,
   }, '생성할 영상 타임라인');
   writeJsonAtomic(path.join(dir, TIMELINE_FILE), timeline);
   return timeline;

--- a/packages/mcp-server/src/video/render.ts
+++ b/packages/mcp-server/src/video/render.ts
@@ -14,10 +14,11 @@ import {
 } from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
+import { formatAss, resolveCaptionStyle } from './captions.js';
 import { readJson, writeJsonAtomic } from './files.js';
 import { loadAssets, loadProject, loadTimeline } from './project.js';
 import { parseFile, renderJobSchema } from './schemas.js';
-import type { VideoAsset, VideoRenderJob, VideoTimeline } from './types.js';
+import type { VideoAsset, VideoRenderJob } from './types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -54,40 +55,6 @@ function readTail(filePath: string, maxBytes = 64 * 1024): string {
     closeSync(fd);
   }
   return buffer.toString('utf8');
-}
-
-function sanitizeSubtitleText(value: string): string {
-  return value
-    .replace(/\r/g, '')
-    .replace(/\n{2,}/g, '\n')
-    .replace(/-->/g, '→')
-    .replace(/</g, '＜')
-    .replace(/>/g, '＞')
-    .replace(/{/g, '｛')
-    .replace(/}/g, '｝')
-    .trim();
-}
-
-function srtTime(seconds: number): string {
-  const ms = Math.max(0, Math.round(seconds * 1000));
-  const hours = Math.floor(ms / 3_600_000);
-  const minutes = Math.floor((ms % 3_600_000) / 60_000);
-  const secs = Math.floor((ms % 60_000) / 1000);
-  const millis = ms % 1000;
-  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')},${String(millis).padStart(3, '0')}`;
-}
-
-export function formatSrt(timeline: VideoTimeline): string {
-  let cursor = 0;
-  const blocks: string[] = [];
-  for (const scene of timeline.scenes) {
-    const text = sanitizeSubtitleText(scene.onScreenText ?? '');
-    const start = cursor;
-    cursor += scene.durationSec;
-    if (!text) continue;
-    blocks.push(`${blocks.length + 1}\n${srtTime(start)} --> ${srtTime(cursor)}\n${text}\n`);
-  }
-  return blocks.join('\n');
 }
 
 function isImage(asset: VideoAsset): boolean {
@@ -143,16 +110,16 @@ export function buildFfmpegPlan(
   ));
   filters.push(`${timeline.scenes.map((_, index) => `[v${index}]`).join('')}concat=n=${timeline.scenes.length}:v=1:a=0[base]`);
 
-  const srt = formatSrt(timeline);
+  const captionStyle = resolveCaptionStyle(project.settings.width, project.settings.height, timeline.captionStyle);
+  const ass = formatAss(timeline, captionStyle);
   let videoLabel = '[base]';
   let subtitlePath: string | undefined;
-  if (srt) {
-    const relativeSubtitlePath = `render/captions-${jobId}.srt`;
+  if (ass) {
+    const relativeSubtitlePath = `render/captions-${jobId}.ass`;
     subtitlePath = path.join(dir, relativeSubtitlePath);
-    writeFileSync(subtitlePath, srt, 'utf8');
-    filters.push(
-      `[base]subtitles=${relativeSubtitlePath}:force_style='FontName=Arial,FontSize=18,PrimaryColour=&H00FFFFFF,OutlineColour=&H80000000,BorderStyle=3,Outline=1,Shadow=0,Alignment=2,MarginV=48'[vout]`,
-    );
+    writeFileSync(subtitlePath, ass, 'utf8');
+    // 스타일(폰트·크기·외곽선·하이라이트)은 ASS 파일에 내장 — force_style을 쓰지 않는다.
+    filters.push(`[base]subtitles=${relativeSubtitlePath}[vout]`);
     videoLabel = '[vout]';
   }
 
@@ -362,4 +329,4 @@ export async function validateVideo(
   return { valid: issues.length === 0, format: data.format ?? {}, streams, issues };
 }
 
-export const __testing = { srtTime, ffprobeFor, sanitizeSubtitleText, processAlive, acquireOutputLock, readTail };
+export const __testing = { ffprobeFor, processAlive, acquireOutputLock, readTail };

--- a/packages/mcp-server/src/video/schemas.ts
+++ b/packages/mcp-server/src/video/schemas.ts
@@ -62,6 +62,18 @@ export const assetManifestSchema = z.object({
   assets: z.array(assetSchema).max(10_000),
 });
 
+export const hexColorSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/, '#RRGGBB 형식이어야 합니다.');
+
+export const captionStyleSchema = z.object({
+  preset: z.enum(['shorts', 'box']).optional(),
+  fontName: z.string().min(1).max(200).optional(),
+  fontSizePx: z.number().int().min(24).max(400).optional(),
+  textColor: hexColorSchema.optional(),
+  outlineColor: hexColorSchema.optional(),
+  highlightColor: hexColorSchema.optional(),
+  position: z.enum(['lower', 'lower-middle', 'center']).optional(),
+});
+
 export const timelineSceneSchema = z.object({
   id: z.string().min(1).max(100),
   assetId: z.string().min(1).max(200),
@@ -80,6 +92,7 @@ export const timelineSchema = z.object({
   totalDurationSec: z.number().finite().positive().max(300),
   scenes: z.array(timelineSceneSchema).min(1).max(30),
   audioAssetId: z.string().min(1).max(200).optional(),
+  captionStyle: captionStyleSchema.optional(),
 }).superRefine((timeline, ctx) => {
   const calculated = timeline.scenes.reduce((sum, scene) => sum + scene.durationSec, 0);
   if (Math.abs(calculated - timeline.totalDurationSec) > 0.01) {

--- a/packages/mcp-server/src/video/types.ts
+++ b/packages/mcp-server/src/video/types.ts
@@ -59,6 +59,16 @@ export interface VideoTimelineScene {
   narration?: string;
 }
 
+export interface VideoCaptionStyle {
+  preset?: 'shorts' | 'box';
+  fontName?: string;
+  fontSizePx?: number;
+  textColor?: string;
+  outlineColor?: string;
+  highlightColor?: string;
+  position?: 'lower' | 'lower-middle' | 'center';
+}
+
 export interface VideoTimeline {
   version: 1;
   projectId: string;
@@ -69,6 +79,7 @@ export interface VideoTimeline {
   totalDurationSec: number;
   scenes: VideoTimelineScene[];
   audioAssetId?: string;
+  captionStyle?: VideoCaptionStyle;
 }
 
 export type VideoJobStatus = 'queued' | 'running' | 'completed' | 'failed';

--- a/packages/mcp-server/tool-manifest.json
+++ b/packages/mcp-server/tool-manifest.json
@@ -1,6 +1,6 @@
 {
   "$comment": "등록된 MCP 도구 + 도메인 메타데이터(label·credential·summary)의 SSOT. src/__tests__/tool-manifest.test.ts 가 실제 서버 등록 목록과 diff 하고 메타데이터 정합성을 검사한다. 도구 추가/삭제/개명 시 이 파일을 함께 갱신할 것 — 산문 문서에는 정확한 개수를 쓰지 말고 이 파일을 가리킬 것. mimi-seed://tools/catalog 리소스가 이 파일을 그대로 서빙한다.",
-  "total": 230,
+  "total": 231,
   "domains": {
     "admob": {
       "label": "AdMob",
@@ -367,6 +367,7 @@
         "youtube_get_video_status",
         "youtube_update_video_privacy",
         "video_plan_from_story",
+        "video_save_plan",
         "video_research_youtube",
         "video_search_stock_assets",
         "video_synthesize_research",

--- a/plugins/mimi-seed/.codex-plugin/plugin.json
+++ b/plugins/mimi-seed/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimi-seed",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Firebase, AdMob, Google Play, App Store Connect와 스토리 기반 영상·YouTube·TikTok Business 게시를 Codex에서 관리하는 MCP 도구·스킬 번들.",
   "author": {
     "name": "yoonion",

--- a/plugins/mimi-seed/docs/agent-guide.md
+++ b/plugins/mimi-seed/docs/agent-guide.md
@@ -80,7 +80,7 @@ you can paste. Pick the row for the job; batching two rows in one `select:` call
 | CI (GitHub/GitLab) | `select:ci_save_config,ci_list_workflows,ci_trigger_build,ci_get_build_status,ci_list_recent_builds,ci_cancel_build` |
 | Android signing / keystore | `select:android_signing_setup,android_generate_keystore,jenkins_upload_keystore,jenkins_upload_playstore_sa` |
 | Service account end-to-end | `select:iam_list_service_accounts,iam_create_service_account,iam_list_keys,iam_create_key,iam_add_iam_policy_binding,setup_playstore_connection,playstore_register_service_account,playstore_verify_service_account,playstore_list_service_accounts,playstore_delete_service_account` |
-| Story → researched video | `select:video_plan_from_story,video_research_youtube,video_search_stock_assets,video_synthesize_research,video_download_stock_assets,video_generate_image,video_add_local_asset,video_build_timeline,video_render,video_job_status,video_validate` |
+| Story → researched video | `select:video_save_plan,video_plan_from_story,video_research_youtube,video_search_stock_assets,video_synthesize_research,video_download_stock_assets,video_generate_image,video_add_local_asset,video_build_timeline,video_render,video_job_status,video_validate` |
 | YouTube upload / publish | `select:youtube_upload_video,youtube_get_video_status,youtube_update_video_privacy,mimi_seed_auth_start` |
 
 ---
@@ -191,7 +191,7 @@ per-domain inventory is [`docs/domain/tool-catalog.md`](domain/tool-catalog.md).
 | **TikTok Business** | `tiktok_business_auth_status` · `tiktok_business_plan_video_post` · `tiktok_business_publish_video` · `tiktok_business_get_publish_status` |
 | **Checks** | `playstore_check_submission_risks` · `appstore_check_submission_risks` · `screenshot_validate` · `release_status` |
 | **AI / Auth** | `generate_release_notes_from_commits` · `generate_review_reply` · `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
-| **Video production** | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
+| **Video production** | `youtube_upload_video` · `youtube_get_video_status` · `youtube_update_video_privacy` · `video_save_plan` · `video_plan_from_story` · `video_research_youtube` · `video_search_stock_assets` · `video_synthesize_research` · `video_generate_image` · `video_build_timeline` · `video_render` · `video_job_status` · `video_validate` |
 
 ---
 
@@ -218,15 +218,16 @@ For visual production, use the bundled `video-create-publish` skill. It requires
 aspect-ratio-specific human-safe crops, video-native motion, an original-resolution frame review, and a saved
 contact sheet; codec validation alone is not a quality pass.
 
-1. `video_plan_from_story` — create the project and scene plan.
+1. `video_save_plan` — save an agent-authored storyboard (no API key; free-path default). `video_plan_from_story` is the metered alternative when `ANTHROPIC_API_KEY` is configured.
 2. `video_research_youtube` — collect reference-only metadata; never treat a result as a render asset.
 3. `video_search_stock_assets` — find licensed Pexels candidates.
 4. `video_synthesize_research` — combine metadata with any direct human/agent observations. Treat its output as
    metadata-bounded guidance, not proof that the source videos were watched.
 5. Preview then confirm `video_download_stock_assets`; use `video_generate_image(confirm=false)` before any paid
-   generation and call it again with `confirm=true` only after approval. User-owned media goes through
-   `video_add_local_asset` with its ownership/license basis.
-6. `video_build_timeline` — provenance-gated scene assignment.
+   generation and call it again with `confirm=true` only after approval. On the free path, generate scene images
+   with the local `codex` CLI (ChatGPT subscription) instead and register them — like all user-owned media —
+   through `video_add_local_asset` with the ownership/license basis.
+6. `video_build_timeline` — provenance-gated scene assignment. Captions burn in the shorts style (bold outline, `**keyword**` highlight); tune with `captionStyle`.
 7. Preview then confirm `video_render`; poll `video_job_status`, then run `video_validate` on the completed MP4.
 
 > **Mimi Seed does not compile app binaries.** It manages metadata, store releases, and

--- a/plugins/mimi-seed/docs/domain/tool-catalog.md
+++ b/plugins/mimi-seed/docs/domain/tool-catalog.md
@@ -1,4 +1,4 @@
-# Tool catalog — 230 tools across 21 domains
+# Tool catalog — 231 tools across 21 domains
 
 > The MCP server's "entities". One row per domain → register file → tools, with **W** (write) and **D**
 > (destructive / near-irreversible) markers. Everything unmarked is read-only.
@@ -31,8 +31,8 @@
 | Auth | `registers/auth.ts` | 4 |
 | Android signing | `registers/android.ts` | 3 |
 | AI | `registers/ai.ts` | 2 |
-| Video production | `registers/video.ts` | 14 |
-| **Total** | **21 modules** | **230** |
+| Video production | `registers/video.ts` | 15 |
+| **Total** | **21 modules** | **231** |
 
 ## Google Play — `registers/playstore.ts` (39) · impl `playstore/tools.ts`
 
@@ -131,13 +131,14 @@
 | Auth (`auth.ts`) | `mimi_seed_status` · `mimi_seed_auth_start` · `mimi_seed_auth_status` · `mimi_seed_remote_sync_credentials` |
 | AI (`ai.ts`) — needs `ANTHROPIC_API_KEY` | `generate_release_notes_from_commits` · `generate_review_reply` |
 
-## Video production — `registers/video.ts` (14) · impl `video/*.ts`
+## Video production — `registers/video.ts` (15) · impl `video/*.ts`
 
 - Research/read: `youtube_get_video_status` · `video_research_youtube` (metadata/reference-only) ·
   `video_search_stock_assets` · `video_job_status` · `video_validate`
 - **W** `youtube_upload_video` (기본 private, public/unlisted는 명시 확인 필수) ·
   `youtube_update_video_privacy` (public/unlisted는 명시 확인 필수)
-- **W** `video_plan_from_story` (Anthropic + local project) · `video_synthesize_research` (metadata/user notes →
+- **W** `video_plan_from_story` (Anthropic + local project) · `video_save_plan` (agent-authored storyboard,
+  no API key — free-path default) · `video_synthesize_research` (metadata/user notes →
   bounded brief) · `video_download_stock_assets` (Pexels, preview then
   confirm) · `video_generate_image` (OpenAI, preview then confirm) · `video_add_local_asset` ·
   `video_build_timeline` · `video_render` (local FFmpeg job, preview then confirm)

--- a/plugins/mimi-seed/skills/video-create-publish/SKILL.md
+++ b/plugins/mimi-seed/skills/video-create-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-create-publish
-description: Create, render, validate, and optionally publish polished short-form videos and YouTube Shorts with Mimi Seed. Use for story-to-video production, vertical social videos, carousel-to-video adaptations, visual-quality revisions, or YouTube upload/status work where typography, human-safe cropping, motion design, asset provenance, and publish confirmation matter.
+description: Create, render, validate, and optionally publish polished short-form videos and YouTube Shorts with Mimi Seed. Use for story-to-video production, vertical social videos, carousel-to-video adaptations, visual-quality revisions, or YouTube upload/status work where typography, shorts-style burned captions, human-safe cropping, motion design, asset provenance, and publish confirmation matter. Defaults to a zero-API-cost path (agent-authored storyboard via video_save_plan, codex CLI image generation) that runs on subscription tokens only.
 ---
 
 # Video Create Publish
@@ -12,22 +12,29 @@ Produce an intentional video rather than a slideshow of generated cards. Preserv
 1. Check scope and connection.
    - Separate create/render from upload/publication; treat public or unlisted upload as irreversible.
    - Load required deferred schemas in one batch, then call `mimi_seed_status`.
-   - For production, load `video_plan_from_story`, research/asset tools actually needed, `video_build_timeline`, `video_render`, `video_job_status`, and `video_validate`.
+   - For production, load `video_save_plan` (or `video_plan_from_story`), research/asset tools actually needed, `video_build_timeline`, `video_render`, `video_job_status`, and `video_validate`.
    - For YouTube, also load `youtube_upload_video`, `youtube_get_video_status`, `youtube_update_video_privacy`, and `mimi_seed_auth_start`.
 
-2. Create the editorial and shot plan.
-   - Define the audience, single takeaway, first-second hook, CTA, target aspect ratio, and maximum duration.
+2. Create the editorial and shot plan — subscription-only by default.
+   - Default to the zero-API-cost path: author the storyboard yourself (you are the subscription-billed model) and save it with `video_save_plan`. Call `video_plan_from_story` only when the user explicitly wants it and `ANTHROPIC_API_KEY` is configured — it bills a metered API key.
+   - Define the audience, single takeaway, first-second hook, CTA, target aspect ratio, and maximum duration. Scene `durationSec` values must sum exactly to `targetDurationSec`.
    - Plan shots as wide/medium/detail or scene/object/UI beats. Do not reuse one still for several consecutive scenes.
-   - Read [references/visual-quality.md](references/visual-quality.md) before selecting fonts, cropping people, or adapting carousel art to video.
+   - Read [references/visual-quality.md](references/visual-quality.md) before selecting fonts, writing captions, cropping people, or adapting carousel art to video.
 
-3. Source assets safely.
-   - Treat YouTube research as reference-only metadata, never renderable media.
-   - Use licensed stock, generated images, or user-owned local assets with the correct ownership/license basis.
-   - Preview paid stock downloads and image generation before confirmation.
-   - Generate art without text; render Korean type deterministically in the editing/rendering layer.
+3. Source assets safely — prefer subscription/free providers.
+   - Treat YouTube research as reference-only metadata, never renderable media. `video_synthesize_research` bills `ANTHROPIC_API_KEY`; on the free path, synthesize the brief yourself.
+   - Generated images: `video_generate_image` bills the metered `OPENAI_API_KEY`. On the free path, generate through the local `codex` CLI instead (ChatGPT subscription; its `image_generation` feature is stable):
+     `codex exec -s workspace-write -C "<projectDir>" "이미지 생성 도구로 <scene visualPrompt>를 1024x1536 세로 이미지로 생성해 assets/generated/<scene-id>.png 로 저장해줘. 이미지 안에 글자는 넣지 마."`
+     Then register each file with `video_add_local_asset` (`sourceType: "user-owned"`, license noting it was generated with the user's own Codex subscription). For 9:16 output keep subjects centered — the renderer cover-crops roughly 9% off each side of a 1024×1536 frame.
+   - Stock (`video_search_stock_assets`/`video_download_stock_assets`) uses the free Pexels API tier; preview downloads before confirmation.
+   - Generate art without text; render Korean type deterministically in the rendering layer.
 
-4. Build a video-native timeline.
+4. Build a video-native timeline with shorts-grade captions.
    - Use `video_build_timeline` only after every selected asset passes provenance checks.
+   - `onScreenText` is burned as styled captions (bold face, white fill, black outline, lower-middle third on 9:16 — the current dominant short-form style). Write it like captions, not paragraphs: 3–5 words per screen, at most 2 lines, break lines by meaning with `\n`.
+   - Highlight exactly one keyword per caption with `**keyword**` (rendered in the highlight color, default `#FFD400`). Never wrap a whole sentence.
+   - Not every scene needs text — reserve captions for hook, evidence, and CTA beats; a silent breathing scene is part of the rhythm.
+   - `captionStyle`: inventory installed fonts first and pass a distinctive bold Korean gothic as `fontName` (e.g. Pretendard, S-Core Dream, 검은고딕) when available; the default falls back to Malgun Gothic Bold — acceptable, but report the fallback. Use `preset: "box"` only for tutorial/step content that needs a translucent subtitle block.
    - Use at least two purposeful motion devices such as subject-aware pan, text reveal, object animation, match cut, progress change, or product/UI capture.
    - Avoid applying the same center zoom to every scene. Keep transitions brief and let narration determine scene duration.
 

--- a/plugins/mimi-seed/skills/video-create-publish/references/visual-quality.md
+++ b/plugins/mimi-seed/skills/video-create-publish/references/visual-quality.md
@@ -8,10 +8,35 @@ Use this gate for every vertical video, especially when adapting 4:5 carousel ar
 - Define a two-role system: a distinctive Korean display face for hooks and a restrained body/caption face. Use no more than two families and three weights.
 - Do not use Malgun Gothic, Gulim, Dotum, Arial, or an unspecified default as the display face. Accept them only as an emergency body fallback and report the fallback.
 - Prefer a licensed project font. When only Windows Korean fonts exist, pair `NotoSerifKR-VF` Bold/Black for display with `NotoSansKR-VF` Medium/Bold for body instead of mixing in Malgun Gothic.
-- For a 1080px-wide vertical video, start at 88px for a hook, 58px for captions, and 42px for minor labels. Shorten copy before shrinking.
+- For text designed into artwork on a 1080px-wide vertical video, start at 88px for a hook, 58px for sub-copy, and 42px for minor labels. Shorten copy before shrinking. Burned captions follow the "Burned captions" section below instead.
 - Break lines by meaning, not character count. Keep a headline to two lines when possible and avoid single-word orphan lines.
 - Set deliberate line height and tracking; do not let library defaults determine either. Use contrast, scale, and spacing before adding pills, outlines, or decorative English labels.
 - Never ask an image model to render final Korean text.
+
+## Burned captions (shorts style)
+
+The renderer burns `onScreenText` as ASS captions. Defaults follow the dominant 2026 short-form
+grammar: bold face, white fill, black outline at 5.5% of the font size (no opaque box), subtle
+fade-in, lower-middle third placement on 9:16 (clear of the Shorts bottom UI and right-side
+buttons), font size ≈ 4.2% of frame height (81px at 1080×1920).
+
+- **Density**: 3–5 words per screen, at most 2 lines. Four or more lines reads as a wall. Break
+  lines by meaning with `\n`, never by character count.
+- **Highlight**: exactly one keyword per caption via `**keyword**` (default `#FFD400` yellow).
+  A fully highlighted sentence is the same as no highlight. Numbers and the payoff word are the
+  best highlight targets.
+- **Not every scene gets text.** Caption the hook, the evidence, and the CTA; let at least one
+  scene breathe. A caption on every beat is a lecture, not a short.
+- **Font**: inventory installed fonts and pass a bold Korean display gothic as
+  `captionStyle.fontName` (Pretendard, S-Core Dream, 검은고딕 in preference order). The built-in
+  fallback is Malgun Gothic Bold — usable for captions, but report the fallback. Never rely on
+  thin/regular weights for burned captions.
+- **Presets**: `shorts` (default) for outline captions with highlights; `box` for tutorial/step
+  content that needs a translucent subtitle block. Do not use `box` for hook-driven shorts.
+- **Position**: keep the default `lower-middle` on 9:16. Override to `center` only for a
+  single-scene title card; `lower` sits closer to platform UI and is for 16:9/1:1.
+- **QC**: on the contact sheet, verify captions against this section — size, line count,
+  highlight count, and that no caption collides with faces or platform UI.
 
 ## Human-safe cropping
 

--- a/skills/video-create-publish/SKILL.md
+++ b/skills/video-create-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-create-publish
-description: Create, render, validate, and optionally publish polished short-form videos and YouTube Shorts with Mimi Seed. Use for story-to-video production, vertical social videos, carousel-to-video adaptations, visual-quality revisions, or YouTube upload/status work where typography, human-safe cropping, motion design, asset provenance, and publish confirmation matter.
+description: Create, render, validate, and optionally publish polished short-form videos and YouTube Shorts with Mimi Seed. Use for story-to-video production, vertical social videos, carousel-to-video adaptations, visual-quality revisions, or YouTube upload/status work where typography, shorts-style burned captions, human-safe cropping, motion design, asset provenance, and publish confirmation matter. Defaults to a zero-API-cost path (agent-authored storyboard via video_save_plan, codex CLI image generation) that runs on subscription tokens only.
 ---
 
 # Video Create Publish
@@ -12,22 +12,29 @@ Produce an intentional video rather than a slideshow of generated cards. Preserv
 1. Check scope and connection.
    - Separate create/render from upload/publication; treat public or unlisted upload as irreversible.
    - Load required deferred schemas in one batch, then call `mimi_seed_status`.
-   - For production, load `video_plan_from_story`, research/asset tools actually needed, `video_build_timeline`, `video_render`, `video_job_status`, and `video_validate`.
+   - For production, load `video_save_plan` (or `video_plan_from_story`), research/asset tools actually needed, `video_build_timeline`, `video_render`, `video_job_status`, and `video_validate`.
    - For YouTube, also load `youtube_upload_video`, `youtube_get_video_status`, `youtube_update_video_privacy`, and `mimi_seed_auth_start`.
 
-2. Create the editorial and shot plan.
-   - Define the audience, single takeaway, first-second hook, CTA, target aspect ratio, and maximum duration.
+2. Create the editorial and shot plan — subscription-only by default.
+   - Default to the zero-API-cost path: author the storyboard yourself (you are the subscription-billed model) and save it with `video_save_plan`. Call `video_plan_from_story` only when the user explicitly wants it and `ANTHROPIC_API_KEY` is configured — it bills a metered API key.
+   - Define the audience, single takeaway, first-second hook, CTA, target aspect ratio, and maximum duration. Scene `durationSec` values must sum exactly to `targetDurationSec`.
    - Plan shots as wide/medium/detail or scene/object/UI beats. Do not reuse one still for several consecutive scenes.
-   - Read [references/visual-quality.md](references/visual-quality.md) before selecting fonts, cropping people, or adapting carousel art to video.
+   - Read [references/visual-quality.md](references/visual-quality.md) before selecting fonts, writing captions, cropping people, or adapting carousel art to video.
 
-3. Source assets safely.
-   - Treat YouTube research as reference-only metadata, never renderable media.
-   - Use licensed stock, generated images, or user-owned local assets with the correct ownership/license basis.
-   - Preview paid stock downloads and image generation before confirmation.
-   - Generate art without text; render Korean type deterministically in the editing/rendering layer.
+3. Source assets safely — prefer subscription/free providers.
+   - Treat YouTube research as reference-only metadata, never renderable media. `video_synthesize_research` bills `ANTHROPIC_API_KEY`; on the free path, synthesize the brief yourself.
+   - Generated images: `video_generate_image` bills the metered `OPENAI_API_KEY`. On the free path, generate through the local `codex` CLI instead (ChatGPT subscription; its `image_generation` feature is stable):
+     `codex exec -s workspace-write -C "<projectDir>" "이미지 생성 도구로 <scene visualPrompt>를 1024x1536 세로 이미지로 생성해 assets/generated/<scene-id>.png 로 저장해줘. 이미지 안에 글자는 넣지 마."`
+     Then register each file with `video_add_local_asset` (`sourceType: "user-owned"`, license noting it was generated with the user's own Codex subscription). For 9:16 output keep subjects centered — the renderer cover-crops roughly 9% off each side of a 1024×1536 frame.
+   - Stock (`video_search_stock_assets`/`video_download_stock_assets`) uses the free Pexels API tier; preview downloads before confirmation.
+   - Generate art without text; render Korean type deterministically in the rendering layer.
 
-4. Build a video-native timeline.
+4. Build a video-native timeline with shorts-grade captions.
    - Use `video_build_timeline` only after every selected asset passes provenance checks.
+   - `onScreenText` is burned as styled captions (bold face, white fill, black outline, lower-middle third on 9:16 — the current dominant short-form style). Write it like captions, not paragraphs: 3–5 words per screen, at most 2 lines, break lines by meaning with `\n`.
+   - Highlight exactly one keyword per caption with `**keyword**` (rendered in the highlight color, default `#FFD400`). Never wrap a whole sentence.
+   - Not every scene needs text — reserve captions for hook, evidence, and CTA beats; a silent breathing scene is part of the rhythm.
+   - `captionStyle`: inventory installed fonts first and pass a distinctive bold Korean gothic as `fontName` (e.g. Pretendard, S-Core Dream, 검은고딕) when available; the default falls back to Malgun Gothic Bold — acceptable, but report the fallback. Use `preset: "box"` only for tutorial/step content that needs a translucent subtitle block.
    - Use at least two purposeful motion devices such as subject-aware pan, text reveal, object animation, match cut, progress change, or product/UI capture.
    - Avoid applying the same center zoom to every scene. Keep transitions brief and let narration determine scene duration.
 

--- a/skills/video-create-publish/references/visual-quality.md
+++ b/skills/video-create-publish/references/visual-quality.md
@@ -8,10 +8,35 @@ Use this gate for every vertical video, especially when adapting 4:5 carousel ar
 - Define a two-role system: a distinctive Korean display face for hooks and a restrained body/caption face. Use no more than two families and three weights.
 - Do not use Malgun Gothic, Gulim, Dotum, Arial, or an unspecified default as the display face. Accept them only as an emergency body fallback and report the fallback.
 - Prefer a licensed project font. When only Windows Korean fonts exist, pair `NotoSerifKR-VF` Bold/Black for display with `NotoSansKR-VF` Medium/Bold for body instead of mixing in Malgun Gothic.
-- For a 1080px-wide vertical video, start at 88px for a hook, 58px for captions, and 42px for minor labels. Shorten copy before shrinking.
+- For text designed into artwork on a 1080px-wide vertical video, start at 88px for a hook, 58px for sub-copy, and 42px for minor labels. Shorten copy before shrinking. Burned captions follow the "Burned captions" section below instead.
 - Break lines by meaning, not character count. Keep a headline to two lines when possible and avoid single-word orphan lines.
 - Set deliberate line height and tracking; do not let library defaults determine either. Use contrast, scale, and spacing before adding pills, outlines, or decorative English labels.
 - Never ask an image model to render final Korean text.
+
+## Burned captions (shorts style)
+
+The renderer burns `onScreenText` as ASS captions. Defaults follow the dominant 2026 short-form
+grammar: bold face, white fill, black outline at 5.5% of the font size (no opaque box), subtle
+fade-in, lower-middle third placement on 9:16 (clear of the Shorts bottom UI and right-side
+buttons), font size ≈ 4.2% of frame height (81px at 1080×1920).
+
+- **Density**: 3–5 words per screen, at most 2 lines. Four or more lines reads as a wall. Break
+  lines by meaning with `\n`, never by character count.
+- **Highlight**: exactly one keyword per caption via `**keyword**` (default `#FFD400` yellow).
+  A fully highlighted sentence is the same as no highlight. Numbers and the payoff word are the
+  best highlight targets.
+- **Not every scene gets text.** Caption the hook, the evidence, and the CTA; let at least one
+  scene breathe. A caption on every beat is a lecture, not a short.
+- **Font**: inventory installed fonts and pass a bold Korean display gothic as
+  `captionStyle.fontName` (Pretendard, S-Core Dream, 검은고딕 in preference order). The built-in
+  fallback is Malgun Gothic Bold — usable for captions, but report the fallback. Never rely on
+  thin/regular weights for burned captions.
+- **Presets**: `shorts` (default) for outline captions with highlights; `box` for tutorial/step
+  content that needs a translucent subtitle block. Do not use `box` for hook-driven shorts.
+- **Position**: keep the default `lower-middle` on 9:16. Override to `center` only for a
+  single-scene title card; `lower` sits closer to platform UI and is for 16:9/1:1.
+- **QC**: on the contact sheet, verify captions against this section — size, line count,
+  highlight count, and that no caption collides with faces or platform UI.
 
 ## Human-safe cropping
 


### PR DESCRIPTION
## 요약
- **자막 개선**: SRT + Arial 18px/불투명 박스 하드코딩 → ASS 자막 시스템(`captions.ts`). 굵은 Bold 고딕·흰 글자+검정 외곽선·9:16 하단-중앙 1/3 배치·`**단어**` 하이라이트·페이드 인. `video_build_timeline`에 `captionStyle` 옵션 (`shorts`/`box` preset).
- **무료 경로**: `video_save_plan` 신규 — API 키 없이 에이전트 작성 스토리보드 저장. 스킬은 이미지 생성을 OPENAI_API_KEY 대신 codex CLI(구독)로 안내.
- **스킬 문서**: visual-quality.md "Burned captions" 섹션(밀도·하이라이트·폰트 규칙), SKILL.md 무료 경로 기본화.
- tool-manifest 230→231, 카탈로그/agent-guide/README 동기화, 버전 0.19.0.

## 테스트
- `npm run test` (plugin:check + mcp-server 567 passed + cli 146 passed) ✅
- 신규: ASS 타이밍/기본 스타일/하이라이트 런/box preset/새니타이즈/`savePlan` 검증 6건

🤖 Generated with [Claude Code](https://claude.com/claude-code)