### PR TITLE
fix: restore Google Ads reporting compatibility

### DIFF
--- a/docs/domain/external-apis.md
+++ b/docs/domain/external-apis.md
@@ -122,6 +122,30 @@ and writes a local audit record. The reservation prevents concurrent workers fro
 remains in place for pending, published, or unknown outcomes. Reconcile through
 `tiktok_business_get_publish_status` or the owned account before retrying.
 
+## Google Ads reporting compatibility
+
+`googleads/tools.ts` owns both MCP reports and the read-only `report:googleads` package script.
+Run the script with two ISO dates after building the MCP package; it reuses `requireAuth` and
+`requireConfig`, never a copied token or a second REST implementation. Output is JSON; failures exit nonzero.
+An already-running MCP process must be restarted to load rebuilt code. Updating source or disk files
+alone does not prove that an existing client is fixed; smoke-test the actual calling path.
+
+- Search requests send `query` and optional `pageToken`, **not `pageSize`**. Google controls page size.
+- Follow every `nextPageToken`. Cost reports have no GAQL `LIMIT` and include removed campaigns;
+  the active campaign inventory is a separate, intentionally filtered view.
+- Campaign inventory queries use `start_date_time` / `end_date_time`, retaining date-only output aliases.
+- `googleads/errors.ts` preserves nested provider codes, field violations and request IDs, redacts current
+  credentials, and never echoes non-JSON proxy bodies. A successful accessible-customers call does not
+  validate report queries. Do not recommend reauthentication merely because Search returns HTTP 400.
+- `cost_micros` is divided by one million into the account currency; campaign reports include currency and
+  account time zone. Historical `cpi` / UAC `installs` output names represent conversions unless conversion
+  action settings independently establish that they are installs. They are not cohort D7 ROAS.
+- Guard: `src/__tests__/googleads.test.ts` covers request bodies, pagination, long-range totals, removed
+  campaigns, dates, supported campaign fields, partial failure, provider diagnostics and secret redaction.
+
+Provider references: [pagination](https://developers.google.com/google-ads/api/docs/reporting/paging),
+[release notes](https://developers.google.com/google-ads/api/docs/release-notes).
+
 ## Security note (public repo)
 
 Error messages may include provider reasons — make sure they never echo **credential values, tokens, `.p8`

--- a/docs/domain/external-apis.md
+++ b/docs/domain/external-apis.md
@@ -133,6 +133,9 @@ alone does not prove that an existing client is fixed; smoke-test the actual cal
 - Search requests send `query` and optional `pageToken`, **not `pageSize`**. Google controls page size.
 - Follow every `nextPageToken`. Cost reports have no GAQL `LIMIT` and include removed campaigns;
   the active campaign inventory is a separate, intentionally filtered view.
+- Repeated cursors and malformed success payloads fail rather than returning partial totals. Invalid
+  numeric metrics fail rather than turning into JSON null or zero. Actual cost micros must be safe integers;
+  average cost metrics may contain fractional micros. Omitted zero-valued protobuf scalars remain valid.
 - Campaign inventory queries use `start_date_time` / `end_date_time`, retaining date-only output aliases.
 - `googleads/errors.ts` preserves nested provider codes, field violations and request IDs, redacts current
   credentials, and never echoes non-JSON proxy bodies. A successful accessible-customers call does not
@@ -140,6 +143,8 @@ alone does not prove that an existing client is fixed; smoke-test the actual cal
 - `cost_micros` is divided by one million into the account currency; campaign reports include currency and
   account time zone. Historical `cpi` / UAC `installs` output names represent conversions unless conversion
   action settings independently establish that they are installs. They are not cohort D7 ROAS.
+- Both MCP report responses and the script include the shared `REPORT_METRIC_NOTE`; prefer the additive
+  `conversions` and `costPerConversion` fields to historical install/CPI aliases.
 - Guard: `src/__tests__/googleads.test.ts` covers request bodies, pagination, long-range totals, removed
   campaigns, dates, supported campaign fields, partial failure, provider diagnostics and secret redaction.
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -20,11 +20,13 @@
   },
   "files": [
     "dist",
+    "scripts/googleads-report.mjs",
     "assets",
     "tool-manifest.json",
     "LICENSE"
   ],
   "scripts": {
+    "report:googleads": "node scripts/googleads-report.mjs",
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "auth": "tsx src/auth/cli.ts",

--- a/packages/mcp-server/scripts/googleads-report.mjs
+++ b/packages/mcp-server/scripts/googleads-report.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Read-only entry point using the same implementation and auth as the MCP tools.
+import process from 'node:process';
+import console from 'node:console';
+import { requireAuth } from '../dist/helpers.js';
+import { requireConfig } from '../dist/googleads/config.js';
+import { getCampaignReport } from '../dist/googleads/tools.js';
+
+const [startDate, endDate, ...extra] = process.argv.slice(2);
+if (!startDate || !endDate || extra.length) {
+  console.error('Usage: node scripts/googleads-report.mjs YYYY-MM-DD YYYY-MM-DD');
+  process.exitCode = 1;
+} else {
+  try {
+    const auth = await requireAuth('https://www.googleapis.com/auth/adwords');
+    const config = requireConfig();
+    const campaigns = await getCampaignReport(auth, config, { startDate, endDate });
+    console.log(JSON.stringify({
+      period: { startDate, endDate },
+      fetchedAt: new Date().toISOString(),
+      customerId: config.customerId,
+      currencyCode: campaigns[0]?.currencyCode ?? null,
+      timeZone: campaigns[0]?.timeZone ?? null,
+      totalCost: campaigns.reduce((sum, row) => sum + row.cost, 0),
+      metricNote: 'cost is account currency, not micros; conversions and legacy cpi are not necessarily installs/CPI.',
+      campaigns,
+    }, null, 2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : 'Google Ads report failed');
+    process.exitCode = 1;
+  }
+}

--- a/packages/mcp-server/scripts/googleads-report.mjs
+++ b/packages/mcp-server/scripts/googleads-report.mjs
@@ -4,7 +4,7 @@ import process from 'node:process';
 import console from 'node:console';
 import { requireAuth } from '../dist/helpers.js';
 import { requireConfig } from '../dist/googleads/config.js';
-import { getCampaignReport } from '../dist/googleads/tools.js';
+import { getCampaignReport, REPORT_METRIC_NOTE } from '../dist/googleads/tools.js';
 
 const [startDate, endDate, ...extra] = process.argv.slice(2);
 if (!startDate || !endDate || extra.length) {
@@ -22,7 +22,7 @@ if (!startDate || !endDate || extra.length) {
       currencyCode: campaigns[0]?.currencyCode ?? null,
       timeZone: campaigns[0]?.timeZone ?? null,
       totalCost: campaigns.reduce((sum, row) => sum + row.cost, 0),
-      metricNote: 'cost is account currency, not micros; conversions and legacy cpi are not necessarily installs/CPI.',
+      metricNote: REPORT_METRIC_NOTE,
       campaigns,
     }, null, 2));
   } catch (error) {

--- a/packages/mcp-server/src/__tests__/googleads.test.ts
+++ b/packages/mcp-server/src/__tests__/googleads.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { listCampaigns, listAccessibleCustomers } from '../googleads/tools.js';
+import { listCampaigns, listAccessibleCustomers, getCampaignReport, getUacReport } from '../googleads/tools.js';
+import { googleAdsError } from '../googleads/errors.js';
 import { normalizeCustomerId } from '../googleads/config.js';
 import type { OAuth2Client } from 'google-auth-library';
 
@@ -24,6 +25,87 @@ describe('googleads 요청', () => {
     vi.stubGlobal('fetch', fetchMock);
   });
   afterEach(() => vi.unstubAllGlobals());
+
+  const range = { startDate: '2026-01-01', endDate: '2026-08-31' };
+
+  it('캠페인 날짜는 지원되는 date_time 필드를 조회하고 기존 날짜 응답을 유지한다', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ results: [{ campaign: {
+      startDateTime: '2026-01-01 00:00:00', endDateTime: '2026-08-31 23:59:59',
+    } }] }) });
+    const rows = await listCampaigns(auth, cfg);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).not.toHaveProperty('pageSize');
+    expect(body.query).toContain('campaign.start_date_time');
+    expect(body.query).toContain('campaign.end_date_time');
+    expect(body.query).not.toMatch(/campaign\.(start_date|end_date)\b/);
+    expect(rows[0]).toMatchObject({ startDate: '2026-01-01', endDate: '2026-08-31' });
+  });
+
+  it('모든 조회 페이지에서 pageSize를 생략하고 nextPageToken으로 비용을 누락 없이 읽는다', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({
+      results: [{ campaign: { id: '1', status: 'REMOVED' }, customer: { currencyCode: 'USD', timeZone: 'UTC' }, metrics: { costMicros: '1234567' } }],
+      nextPageToken: 'page-two',
+    }) }).mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({
+      results: [{ campaign: { id: '2' }, metrics: { costMicros: '2000000' } }],
+    }) });
+    const rows = await getCampaignReport(auth, cfg, range);
+    expect(rows.reduce((sum, row) => sum + row.cost, 0)).toBeCloseTo(3.234567);
+    expect(rows[0]).toMatchObject({ status: 'REMOVED', currencyCode: 'USD', timeZone: 'UTC' });
+    const bodies = fetchMock.mock.calls.map((call) => JSON.parse(call[1].body));
+    expect(bodies).toHaveLength(2);
+    expect(Object.keys(bodies[0])).toEqual(['query']);
+    expect(Object.keys(bodies[1]).sort()).toEqual(['pageToken', 'query']);
+    expect(bodies[1].pageToken).toBe('page-two');
+    expect(bodies[1].query).toBe(bodies[0].query);
+    expect(bodies[0].query).not.toMatch(/LIMIT|status\s*!=/i);
+  });
+
+  it('UAC 장기 일별 보고서는 500행에서 잘리지 않고 페이지별 동일 캠페인을 합산한다', async () => {
+    const row = { campaign: { id: '1' }, metrics: { costMicros: '1000000', conversions: '2' }, segments: { date: '2026-01-01' } };
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ results: Array(500).fill(row), nextPageToken: 'next' }) })
+      .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ results: [row] }) });
+    const rows = await getUacReport(auth, cfg, range);
+    expect(rows[0].cost).toBe(501);
+    expect(rows[0].installs).toBe(1002); // Legacy name; this metric counts conversions, not necessarily installs.
+    for (const call of fetchMock.mock.calls) {
+      const body = JSON.parse(call[1].body);
+      expect(body).not.toHaveProperty('pageSize');
+      expect(body.query).not.toMatch(/LIMIT/i);
+    }
+  });
+
+  it.each([listCampaigns, listAccessibleCustomers])('Google 상세 오류 코드와 requestId를 보존한다', async (read) => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 400, text: async () => JSON.stringify({ error: {
+      message: 'Request contains an invalid argument.', details: [{ errors: [{
+        errorCode: { requestError: 'PAGE_SIZE_NOT_SUPPORTED' }, message: 'Setting the page size is not supported.',
+      }], requestId: 'example-request' }],
+    } }) });
+    await expect(read(auth, cfg)).rejects.toThrow(/PAGE_SIZE_NOT_SUPPORTED[\s\S]*example-request/);
+  });
+
+  it('후속 페이지 오류를 빈/부분 성공으로 숨기지 않는다', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ results: [], nextPageToken: 'next' }) })
+      .mockResolvedValueOnce({ ok: false, status: 400, text: async () => '{}' });
+    await expect(getCampaignReport(auth, cfg, range)).rejects.toThrow('Google Ads API 400');
+  });
+
+  it.each(['2026-02-30', "2026-01-01' OR 1=1", 'bad-date'])('유효하지 않은 날짜는 요청 전에 차단한다: %s', async (startDate) => {
+    await expect(getCampaignReport(auth, cfg, { ...range, startDate })).rejects.toThrow('calendar dates');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('역전된 기간을 차단한다', async () => {
+    await expect(getUacReport(auth, cfg, { startDate: range.endDate, endDate: range.startDate })).rejects.toThrow('startDate');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('오류 메시지에서 토큰을 지우고 비 JSON 본문을 노출하지 않는다', () => {
+    const error = googleAdsError(400, JSON.stringify([{ error: { message: 'Bearer example-access example-developer', details: [{ fieldViolations: [{ field: 'pageSize', description: 'invalid field' }] }] } }]), ['example-access', 'example-developer']);
+    expect(error.message).toContain('pageSize: invalid field');
+    expect(error.message).not.toContain('example-access');
+    expect(error.message).not.toContain('example-developer');
+    expect(googleAdsError(502, '<html>private</html>', []).message).not.toContain('private');
+  });
 
   it('sunset 된 v17 이 아니라 지원되는 API 버전 사용 + customer 경로', async () => {
     await listCampaigns(auth, cfg);

--- a/packages/mcp-server/src/__tests__/googleads.test.ts
+++ b/packages/mcp-server/src/__tests__/googleads.test.ts
@@ -28,6 +28,41 @@ describe('googleads 요청', () => {
 
   const range = { startDate: '2026-01-01', endDate: '2026-08-31' };
 
+  it('반복 페이지 토큰은 무한 루프 대신 실패한다', async () => {
+    fetchMock.mockResolvedValue({ ok: true, text: async () => JSON.stringify({ results: [], nextPageToken: 'loop' }) });
+    await expect(getCampaignReport(auth, cfg, range)).rejects.toThrow('repeated a page token');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([null, [], { results: {} }, { results: [null] }, { results: [{}] }, { error: {} }, { nextPageToken: 123 }])('비정상 성공 응답을 0원으로 처리하지 않는다: %j', async (response) => {
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify(response) });
+    await expect(getCampaignReport(auth, cfg, range)).rejects.toThrow('invalid search response');
+  });
+
+  it('비 JSON 성공 응답 본문을 오류에 노출하지 않는다', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => 'private-invalid-json' });
+    await expect(getCampaignReport(auth, cfg, range)).rejects.toThrow(/^Google Ads returned invalid JSON\.$/);
+  });
+
+  it.each(['NaN', 'Infinity', '', ' ', null, false, '9007199254740993', '1.5'])('비정상 비용을 null/0원/부정확한 숫자로 반환하지 않는다: %j', async (costMicros) => {
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ results: [{ campaign: { id: '1' }, metrics: { costMicros } }] }) });
+    await expect(getCampaignReport(auth, cfg, range)).rejects.toThrow(/numeric metric|currency micros/);
+  });
+
+  it('metrics 누락은 실패하지만 Google의 생략된 0 스칼라는 허용한다', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ results: [{ campaign: { id: '1' } }] }) });
+    await expect(getCampaignReport(auth, cfg, range)).rejects.toThrow('missing metrics');
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ results: [{ campaign: { id: '1' }, metrics: {} }] }) });
+    expect((await getCampaignReport(auth, cfg, range))[0]).toMatchObject({ cost: 0, costPerConversion: null });
+  });
+
+  it('전환당 평균 비용의 소수 micros는 정수 비용과 구분한다', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ results: [{ campaign: { id: '1' }, metrics: { costMicros: '1000000', conversions: '3', costPerConversion: 333333.333333 } }] }) });
+    const [row] = await getCampaignReport(auth, cfg, range);
+    expect(row.costPerConversion).toBeCloseTo(1 / 3);
+    expect(row.cpi).toBe(row.costPerConversion);
+  });
+
   it('캠페인 날짜는 지원되는 date_time 필드를 조회하고 기존 날짜 응답을 유지한다', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify({ results: [{ campaign: {
       startDateTime: '2026-01-01 00:00:00', endDateTime: '2026-08-31 23:59:59',
@@ -67,6 +102,8 @@ describe('googleads 요청', () => {
     const rows = await getUacReport(auth, cfg, range);
     expect(rows[0].cost).toBe(501);
     expect(rows[0].installs).toBe(1002); // Legacy name; this metric counts conversions, not necessarily installs.
+    expect(rows[0].conversions).toBe(1002);
+    expect(rows[0].costPerConversion).toBe(0.5);
     for (const call of fetchMock.mock.calls) {
       const body = JSON.parse(call[1].body);
       expect(body).not.toHaveProperty('pageSize');

--- a/packages/mcp-server/src/googleads/errors.ts
+++ b/packages/mcp-server/src/googleads/errors.ts
@@ -1,0 +1,28 @@
+/** Preserve provider diagnostics without exposing authentication material. */
+export function googleAdsError(status: number, body: string, secrets: string[]): Error {
+  let message = `Google Ads API ${status}`;
+  try {
+    const parsed = JSON.parse(body);
+    const error = (Array.isArray(parsed) ? parsed[0] : parsed)?.error;
+    if (typeof error?.message === 'string') message += `: ${error.message}`;
+    for (const detail of Array.isArray(error?.details) ? error.details : []) {
+      for (const item of Array.isArray(detail.errors) ? detail.errors : []) {
+        const codes = item.errorCode && typeof item.errorCode === 'object'
+          ? Object.entries(item.errorCode).map(([key, value]) => `${key}=${String(value)}`).join(', ')
+          : '';
+        message += `\n${codes}${typeof item.message === 'string' ? `: ${item.message}` : ''}`;
+      }
+      for (const item of Array.isArray(detail.fieldViolations) ? detail.fieldViolations : []) {
+        message += `\n${String(item.field ?? '')}: ${String(item.description ?? '')}`;
+      }
+      if (typeof detail.requestId === 'string') message += `\nrequestId=${detail.requestId}`;
+    }
+  } catch {
+    // HTML/proxy bodies can contain arbitrary data; do not echo them.
+    message += ': non-JSON response';
+  }
+  for (const secret of secrets.filter(Boolean).sort((a, b) => b.length - a.length)) {
+    message = message.split(secret).join('[REDACTED]');
+  }
+  return new Error(message.slice(0, 4000));
+}

--- a/packages/mcp-server/src/googleads/tools.ts
+++ b/packages/mcp-server/src/googleads/tools.ts
@@ -1,6 +1,7 @@
 import type { OAuth2Client } from 'google-auth-library';
 import type { GoogleAdsConfig } from './config.js';
 import { fetchWithTimeout } from '../lib/http.js';
+import { googleAdsError } from './errors.js';
 
 // Google Ads API는 ~13개월 주기로 sunset (항상 최신 3개 major만 유지).
 // v24 = 2026-06 기준 현행 major. 새 major 출시 시 갱신 필요.
@@ -11,6 +12,16 @@ const BASE = `https://googleads.googleapis.com/${API_VERSION}`;
 export interface DateRange {
   startDate: string; // YYYY-MM-DD
   endDate: string;   // YYYY-MM-DD
+}
+
+function validateDateRange(range: DateRange): void {
+  for (const value of [range.startDate, range.endDate]) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value) ||
+      !Number.isFinite(Date.parse(value)) || new Date(value).toISOString().slice(0, 10) !== value) {
+      throw new Error('Google Ads dates must be valid YYYY-MM-DD calendar dates.');
+    }
+  }
+  if (range.startDate > range.endDate) throw new Error('Google Ads startDate must not exceed endDate.');
 }
 
 // ─── 내부 헬퍼 ───────────────────────────────────────────────
@@ -46,7 +57,8 @@ async function search(
   let pageToken: string | undefined;
 
   do {
-    const body: Record<string, unknown> = { query, pageSize: 1000 };
+    // Google Ads controls page size; sending pageSize is rejected by current APIs.
+    const body: Record<string, unknown> = { query };
     if (pageToken) body.pageToken = pageToken;
 
     const res = await fetchWithTimeout(url, {
@@ -57,15 +69,7 @@ async function search(
 
     const text = await res.text();
     if (!res.ok) {
-      let msg = `Google Ads API ${res.status}`;
-      try {
-        const err = JSON.parse(text);
-        const detail = err?.error?.message ?? err?.[0]?.error?.message ?? text;
-        msg += `: ${detail}`;
-      } catch {
-        msg += `: ${text.slice(0, 300)}`;
-      }
-      throw new Error(msg);
+      throw googleAdsError(res.status, text, [accessToken, cfg.developerToken]);
     }
 
     const json = JSON.parse(text);
@@ -92,14 +96,7 @@ export async function listAccessibleCustomers(auth: OAuth2Client, cfg: GoogleAds
   });
   const text = await res.text();
   if (!res.ok) {
-    let msg = `Google Ads API ${res.status}`;
-    try {
-      const err = JSON.parse(text);
-      msg += `: ${err?.error?.message ?? text.slice(0, 300)}`;
-    } catch {
-      msg += `: ${text.slice(0, 300)}`;
-    }
-    throw new Error(msg);
+    throw googleAdsError(res.status, text, [accessToken, cfg.developerToken]);
   }
   return JSON.parse(text);
 }
@@ -114,8 +111,8 @@ export async function listCampaigns(auth: OAuth2Client, cfg: GoogleAdsConfig) {
       campaign.status,
       campaign.advertising_channel_type,
       campaign.advertising_channel_sub_type,
-      campaign.start_date,
-      campaign.end_date,
+      campaign.start_date_time,
+      campaign.end_date_time,
       campaign_budget.amount_micros
     FROM campaign
     WHERE campaign.status != 'REMOVED'
@@ -130,8 +127,9 @@ export async function listCampaigns(auth: OAuth2Client, cfg: GoogleAdsConfig) {
     status: r.campaign?.status,
     channelType: r.campaign?.advertisingChannelType,
     channelSubType: r.campaign?.advertisingChannelSubType,
-    startDate: r.campaign?.startDate,
-    endDate: r.campaign?.endDate,
+    // Keep date-only response fields compatible while querying the supported schema.
+    startDate: r.campaign?.startDateTime?.slice(0, 10),
+    endDate: r.campaign?.endDateTime?.slice(0, 10),
     dailyBudget: microsToCurrency(r.campaignBudget?.amountMicros),
   }));
 }
@@ -143,8 +141,11 @@ export async function getCampaignReport(
   cfg: GoogleAdsConfig,
   range: DateRange,
 ) {
+  validateDateRange(range);
   const query = `
     SELECT
+      customer.currency_code,
+      customer.time_zone,
       campaign.id,
       campaign.name,
       campaign.status,
@@ -159,14 +160,14 @@ export async function getCampaignReport(
       metrics.ctr,
       metrics.average_cpc
     FROM campaign
-    WHERE campaign.status != 'REMOVED'
-      AND segments.date BETWEEN '${range.startDate}' AND '${range.endDate}'
+    WHERE segments.date BETWEEN '${range.startDate}' AND '${range.endDate}'
     ORDER BY metrics.cost_micros DESC
-    LIMIT 500
   `;
 
   const rows = await search(auth, cfg, query);
   return rows.map((r: any) => ({
+    currencyCode: r.customer?.currencyCode,
+    timeZone: r.customer?.timeZone,
     id: r.campaign?.id,
     name: r.campaign?.name,
     status: r.campaign?.status,
@@ -190,6 +191,7 @@ export async function getUacReport(
   cfg: GoogleAdsConfig,
   range: DateRange,
 ) {
+  validateDateRange(range);
   const query = `
     SELECT
       campaign.id,
@@ -209,7 +211,6 @@ export async function getUacReport(
       AND campaign.advertising_channel_sub_type IN ('APP_CAMPAIGN', 'APP_CAMPAIGN_FOR_ENGAGEMENT', 'APP_CAMPAIGN_FOR_PRE_REGISTRATION')
       AND segments.date BETWEEN '${range.startDate}' AND '${range.endDate}'
     ORDER BY segments.date DESC, metrics.cost_micros DESC
-    LIMIT 500
   `;
 
   const rows = await search(auth, cfg, query);

--- a/packages/mcp-server/src/googleads/tools.ts
+++ b/packages/mcp-server/src/googleads/tools.ts
@@ -9,6 +9,21 @@ import { googleAdsError } from './errors.js';
 const API_VERSION = 'v24';
 const BASE = `https://googleads.googleapis.com/${API_VERSION}`;
 
+export const REPORT_METRIC_NOTE = 'cost is in account currency, not micros. conversions are Google Ads conversions, not necessarily installs. Legacy installs/cpi aliases do not establish install CPI or cohort D7 ROAS.';
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function metricNumber(value: unknown): number {
+  // Protobuf JSON can omit zero-valued scalars, but explicit malformed values are not zero.
+  if (value === undefined) return 0;
+  if ((typeof value !== 'number' && typeof value !== 'string') ||
+    (typeof value === 'string' && !/^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(value)) ||
+    !Number.isFinite(Number(value))) throw new Error('Google Ads returned an invalid numeric metric.');
+  return Number(value);
+}
+
 export interface DateRange {
   startDate: string; // YYYY-MM-DD
   endDate: string;   // YYYY-MM-DD
@@ -55,6 +70,7 @@ async function search(
 
   const all: any[] = [];
   let pageToken: string | undefined;
+  const seenTokens = new Set<string>();
 
   do {
     // Google Ads controls page size; sending pageSize is rejected by current APIs.
@@ -72,17 +88,29 @@ async function search(
       throw googleAdsError(res.status, text, [accessToken, cfg.developerToken]);
     }
 
-    const json = JSON.parse(text);
+    let json: any;
+    try { json = JSON.parse(text); } catch { throw new Error('Google Ads returned invalid JSON.'); }
+    if (!isRecord(json) || 'error' in json ||
+      (json.results !== undefined && !Array.isArray(json.results)) ||
+      (json.nextPageToken !== undefined && typeof json.nextPageToken !== 'string') ||
+      (json.results ?? []).some((row: unknown) => !isRecord(row) || !isRecord(row.campaign))) {
+      throw new Error('Google Ads returned an invalid search response.');
+    }
     all.push(...(json.results ?? []));
     pageToken = json.nextPageToken ?? undefined;
+    if (pageToken) {
+      if (seenTokens.has(pageToken)) throw new Error('Google Ads repeated a page token; refusing partial totals.');
+      seenTokens.add(pageToken);
+    }
   } while (pageToken);
 
   return all;
 }
 
 function microsToCurrency(micros: string | number | undefined): number {
-  if (micros == null) return 0;
-  return Number(micros) / 1_000_000;
+  const value = metricNumber(micros);
+  if (!Number.isSafeInteger(value)) throw new Error('Google Ads returned unsafe or fractional currency micros.');
+  return value / 1_000_000;
 }
 
 // ─── 접근 가능한 고객 목록 (API 연결 확인용) ─────────────────────
@@ -165,6 +193,9 @@ export async function getCampaignReport(
   `;
 
   const rows = await search(auth, cfg, query);
+  for (const row of rows) {
+    if (!isRecord(row.metrics)) throw new Error('Google Ads report row is missing metrics.');
+  }
   return rows.map((r: any) => ({
     currencyCode: r.customer?.currencyCode,
     timeZone: r.customer?.timeZone,
@@ -173,14 +204,16 @@ export async function getCampaignReport(
     status: r.campaign?.status,
     channelType: r.campaign?.advertisingChannelType,
     channelSubType: r.campaign?.advertisingChannelSubType,
-    clicks: Number(r.metrics?.clicks ?? 0),
-    impressions: Number(r.metrics?.impressions ?? 0),
+    clicks: metricNumber(r.metrics?.clicks),
+    impressions: metricNumber(r.metrics?.impressions),
     cost: microsToCurrency(r.metrics?.costMicros),
-    conversions: Number(r.metrics?.conversions ?? 0),
-    conversionsValue: Number(r.metrics?.conversionsValue ?? 0),
-    cpi: microsToCurrency(r.metrics?.costPerConversion),
-    ctr: Number(r.metrics?.ctr ?? 0),
-    avgCpc: microsToCurrency(r.metrics?.averageCpc),
+    conversions: metricNumber(r.metrics?.conversions),
+    conversionsValue: metricNumber(r.metrics?.conversionsValue),
+    costPerConversion: metricNumber(r.metrics?.conversions) > 0
+      ? metricNumber(r.metrics?.costPerConversion) / 1_000_000 : null,
+    cpi: metricNumber(r.metrics?.costPerConversion) / 1_000_000,
+    ctr: metricNumber(r.metrics?.ctr),
+    avgCpc: metricNumber(r.metrics?.averageCpc) / 1_000_000,
   }));
 }
 
@@ -223,16 +256,17 @@ export async function getUacReport(
   }>();
 
   for (const r of rows) {
+    if (!isRecord(r.metrics) || !r.campaign?.id) throw new Error('Google Ads UAC row is missing campaign or metrics.');
     const id = String(r.campaign?.id ?? '');
     const existing = byId.get(id);
     const cost = microsToCurrency(r.metrics?.costMicros);
-    const installs = Number(r.metrics?.conversions ?? 0);
+    const installs = metricNumber(r.metrics?.conversions);
     if (existing) {
-      existing.clicks += Number(r.metrics?.clicks ?? 0);
-      existing.impressions += Number(r.metrics?.impressions ?? 0);
+      existing.clicks += metricNumber(r.metrics?.clicks);
+      existing.impressions += metricNumber(r.metrics?.impressions);
       existing.cost += cost;
       existing.installs += installs;
-      existing.installsValue += Number(r.metrics?.conversionsValue ?? 0);
+      existing.installsValue += metricNumber(r.metrics?.conversionsValue);
       if (r.segments?.date) existing.dates.push(r.segments.date);
     } else {
       byId.set(id, {
@@ -240,11 +274,11 @@ export async function getUacReport(
         name: r.campaign?.name ?? '',
         status: r.campaign?.status ?? '',
         subType: r.campaign?.advertisingChannelSubType ?? '',
-        clicks: Number(r.metrics?.clicks ?? 0),
-        impressions: Number(r.metrics?.impressions ?? 0),
+        clicks: metricNumber(r.metrics?.clicks),
+        impressions: metricNumber(r.metrics?.impressions),
         cost,
         installs,
-        installsValue: Number(r.metrics?.conversionsValue ?? 0),
+        installsValue: metricNumber(r.metrics?.conversionsValue),
         dates: r.segments?.date ? [r.segments.date] : [],
       });
     }
@@ -258,6 +292,9 @@ export async function getUacReport(
     clicks: c.clicks,
     impressions: c.impressions,
     cost: c.cost,
+    conversions: c.installs,
+    conversionsValue: c.installsValue,
+    costPerConversion: c.installs > 0 ? c.cost / c.installs : null,
     installs: c.installs,
     installsValue: c.installsValue,
     cpi: c.installs > 0 ? c.cost / c.installs : 0,

--- a/packages/mcp-server/src/registers/googleads.ts
+++ b/packages/mcp-server/src/registers/googleads.ts
@@ -48,7 +48,7 @@ export function registerGoogleAdsTools(server: McpServer) {
 
   server.tool(
     'googleads_get_campaign_report',
-    '기간별 캠페인 성과 리포트 (클릭, 노출, 비용, 전환수, CPI, CTR)',
+    '기간별 캠페인 성과 리포트 (클릭, 노출, 계정 통화 비용, 전환수, 전환당 비용). 설치 CPI나 코호트 ROAS가 아님.',
     {
       startDate: z.string().describe('시작일 (YYYY-MM-DD)'),
       endDate: z.string().describe('종료일 (YYYY-MM-DD)'),
@@ -68,6 +68,7 @@ export function registerGoogleAdsTools(server: McpServer) {
           type: 'text',
           text: JSON.stringify({
             period: { startDate, endDate },
+            metricNote: googleads.REPORT_METRIC_NOTE,
             summary: {
               totalCost: Math.round(totalCost * 100) / 100,
               totalClicks,
@@ -84,7 +85,7 @@ export function registerGoogleAdsTools(server: McpServer) {
 
   server.tool(
     'googleads_get_uac_report',
-    '앱 캠페인(UAC) 리포트 — 앱 설치 캠페인별 설치수, CPI, ROAS 집계',
+    '앱 캠페인(UAC) 비용·전환 리포트. legacy installs/cpi 필드는 일반 전환 기반 별칭이며 설치수·설치 CPI·D7 ROAS로 단정하지 말 것.',
     {
       startDate: z.string().describe('시작일 (YYYY-MM-DD)'),
       endDate: z.string().describe('종료일 (YYYY-MM-DD)'),
@@ -102,9 +103,11 @@ export function registerGoogleAdsTools(server: McpServer) {
           type: 'text',
           text: JSON.stringify({
             period: { startDate, endDate },
+            metricNote: googleads.REPORT_METRIC_NOTE,
             summary: {
               totalCost: Math.round(totalCost * 100) / 100,
               totalInstalls,
+              totalConversions: totalInstalls,
               avgCpi: totalInstalls > 0 ? Math.round(totalCost / totalInstalls * 100) / 100 : null,
               campaignCount: report.length,
             },

--- a/plugins/mimi-seed/docs/domain/external-apis.md
+++ b/plugins/mimi-seed/docs/domain/external-apis.md
@@ -122,6 +122,30 @@ and writes a local audit record. The reservation prevents concurrent workers fro
 remains in place for pending, published, or unknown outcomes. Reconcile through
 `tiktok_business_get_publish_status` or the owned account before retrying.
 
+## Google Ads reporting compatibility
+
+`googleads/tools.ts` owns both MCP reports and the read-only `report:googleads` package script.
+Run the script with two ISO dates after building the MCP package; it reuses `requireAuth` and
+`requireConfig`, never a copied token or a second REST implementation. Output is JSON; failures exit nonzero.
+An already-running MCP process must be restarted to load rebuilt code. Updating source or disk files
+alone does not prove that an existing client is fixed; smoke-test the actual calling path.
+
+- Search requests send `query` and optional `pageToken`, **not `pageSize`**. Google controls page size.
+- Follow every `nextPageToken`. Cost reports have no GAQL `LIMIT` and include removed campaigns;
+  the active campaign inventory is a separate, intentionally filtered view.
+- Campaign inventory queries use `start_date_time` / `end_date_time`, retaining date-only output aliases.
+- `googleads/errors.ts` preserves nested provider codes, field violations and request IDs, redacts current
+  credentials, and never echoes non-JSON proxy bodies. A successful accessible-customers call does not
+  validate report queries. Do not recommend reauthentication merely because Search returns HTTP 400.
+- `cost_micros` is divided by one million into the account currency; campaign reports include currency and
+  account time zone. Historical `cpi` / UAC `installs` output names represent conversions unless conversion
+  action settings independently establish that they are installs. They are not cohort D7 ROAS.
+- Guard: `src/__tests__/googleads.test.ts` covers request bodies, pagination, long-range totals, removed
+  campaigns, dates, supported campaign fields, partial failure, provider diagnostics and secret redaction.
+
+Provider references: [pagination](https://developers.google.com/google-ads/api/docs/reporting/paging),
+[release notes](https://developers.google.com/google-ads/api/docs/release-notes).
+
 ## Security note (public repo)
 
 Error messages may include provider reasons — make sure they never echo **credential values, tokens, `.p8`

--- a/plugins/mimi-seed/docs/domain/external-apis.md
+++ b/plugins/mimi-seed/docs/domain/external-apis.md
@@ -133,6 +133,9 @@ alone does not prove that an existing client is fixed; smoke-test the actual cal
 - Search requests send `query` and optional `pageToken`, **not `pageSize`**. Google controls page size.
 - Follow every `nextPageToken`. Cost reports have no GAQL `LIMIT` and include removed campaigns;
   the active campaign inventory is a separate, intentionally filtered view.
+- Repeated cursors and malformed success payloads fail rather than returning partial totals. Invalid
+  numeric metrics fail rather than turning into JSON null or zero. Actual cost micros must be safe integers;
+  average cost metrics may contain fractional micros. Omitted zero-valued protobuf scalars remain valid.
 - Campaign inventory queries use `start_date_time` / `end_date_time`, retaining date-only output aliases.
 - `googleads/errors.ts` preserves nested provider codes, field violations and request IDs, redacts current
   credentials, and never echoes non-JSON proxy bodies. A successful accessible-customers call does not
@@ -140,6 +143,8 @@ alone does not prove that an existing client is fixed; smoke-test the actual cal
 - `cost_micros` is divided by one million into the account currency; campaign reports include currency and
   account time zone. Historical `cpi` / UAC `installs` output names represent conversions unless conversion
   action settings independently establish that they are installs. They are not cohort D7 ROAS.
+- Both MCP report responses and the script include the shared `REPORT_METRIC_NOTE`; prefer the additive
+  `conversions` and `costPerConversion` fields to historical install/CPI aliases.
 - Guard: `src/__tests__/googleads.test.ts` covers request bodies, pagination, long-range totals, removed
   campaigns, dates, supported campaign fields, partial failure, provider diagnostics and secret redaction.
 


### PR DESCRIPTION
## Summary
- remove unsupported Google Ads search pageSize and follow every page token
- update removed v24 campaign date fields and preserve provider diagnostics safely
- prevent partial/malformed cost totals and clarify conversion-vs-install semantics
- add a read-only report command using the same implementation

## Verification
- MCP package build passes
- 67 test files pass, 681 tests pass, 2 skipped
- plugin drift checks pass
- live read-only campaign and UAC reports agree on the same recent-period cost